### PR TITLE
Fixing Argument out of range exception for HtmlTextWriter Style and pushing HtmlTextWriter webformsfeed

### DIFF
--- a/src/HtmlTextWriter/CssTextWriter.cs
+++ b/src/HtmlTextWriter/CssTextWriter.cs
@@ -15,11 +15,12 @@ internal sealed class CssTextWriter : TextWriter
     private readonly TextWriter _writer;
 
     private static readonly Dictionary<string, HtmlTextWriterStyle> attrKeyLookupTable = new(StringComparer.OrdinalIgnoreCase);
-    private static readonly List<AttributeInformation> attrNameLookupArray = new();
+    private static readonly AttributeInformation[] attrNameLookupArray; 
 
     [Diagnostics.CodeAnalysis.SuppressMessage("Performance", "CA1810:Initialize reference type static fields inline", Justification = "<Pending>")]
     static CssTextWriter()
     {
+        attrNameLookupArray  = new AttributeInformation[(int)HtmlTextWriterStyle.ZIndex + 1];
         // register known style attributes, HtmlTextWriterStyle.Length
         RegisterAttribute("background-color", HtmlTextWriterStyle.BackgroundColor);
         RegisterAttribute("background-image", HtmlTextWriterStyle.BackgroundImage, true, true);
@@ -124,7 +125,7 @@ internal sealed class CssTextWriter : TextWriter
     /// </summary>
     public static string GetStyleName(HtmlTextWriterStyle styleKey)
     {
-        return (int)styleKey >= 0 && (int)styleKey < attrNameLookupArray.Count ? attrNameLookupArray[(int)styleKey].Name : string.Empty;
+        return (int)styleKey >= 0 && (int)styleKey < attrNameLookupArray.Length ? attrNameLookupArray[(int)styleKey].Name : string.Empty;
     }
 
     /// <summary>
@@ -133,7 +134,7 @@ internal sealed class CssTextWriter : TextWriter
     /// </summary>
     public static bool IsStyleEncoded(HtmlTextWriterStyle styleKey)
     {
-        return (int)styleKey >= 0 && (int)styleKey < attrNameLookupArray.Count ? attrNameLookupArray[(int)styleKey].Encode : true;
+        return (int)styleKey >= 0 && (int)styleKey < attrNameLookupArray.Length ? attrNameLookupArray[(int)styleKey].Encode : true;
     }
 
     /// <internalonly/>
@@ -167,7 +168,7 @@ internal sealed class CssTextWriter : TextWriter
     {
         attrKeyLookupTable[name] = key;
 
-        if ((int)key < attrNameLookupArray.Count)
+        if ((int)key < attrNameLookupArray.Length)
         {
             attrNameLookupArray[(int)key] = new AttributeInformation(name, encode, isUrl);
         }

--- a/src/HtmlTextWriter/HtmlTextWriter.csproj
+++ b/src/HtmlTextWriter/HtmlTextWriter.csproj
@@ -1,9 +1,12 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
+    <IsShipped>true</IsShipped>
     <TargetFramework>net6.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
+    <AssemblyName>WebForms.HtmlTextWriter</AssemblyName>
+    <RootNamespace>System.Web</RootNamespace>
   </PropertyGroup>
 
 </Project>


### PR DESCRIPTION
While writing attributes a check is done per index as displayed https://github.com/CoreWebForms/CoreWebForms/blob/main/src/HtmlTextWriter/CssTextWriter.cs#L282 which was causing the Outof range exception. The reason for out of range exception while porting we change the data structure to List instead of array as here https://referencesource.microsoft.com/#System.Web/UI/CssTextWriter.cs,28 . I have changed to keep as an array as there is no much performance or space gain. LMK what you think?

Also made the HtmlTextWriter.csproj as shipped to be available in webformsfeed.