### PR TITLE
Abstract parser registration for compilation

### DIFF
--- a/src/Compiler.Dynamic/PageCompilationOptions.cs
+++ b/src/Compiler.Dynamic/PageCompilationOptions.cs
@@ -2,6 +2,7 @@
 
 using System.Reflection;
 using System.Web;
+using System.Web.Compilation;
 using System.Web.UI;
 using System.Web.UI.WebControls;
 using Microsoft.Extensions.FileProviders;
@@ -27,6 +28,24 @@ public class PageCompilationOptions
         AddAssembly(typeof(HttpUtility).Assembly);
         AddAssembly(typeof(IHttpHandler).Assembly);
         AddAssembly(typeof(HttpContext).Assembly);
+    }
+
+    internal Dictionary<string, Func<string, BaseCodeDomTreeGenerator>> Parsers { get; } = new(StringComparer.OrdinalIgnoreCase);
+
+    internal void AddParser<TParser>(string extension)
+        where TParser : BaseTemplateParser, new()
+    {
+        Parsers.Add(extension, Create);
+
+        static BaseCodeDomTreeGenerator Create(string path)
+        {
+            var parser = new TParser();
+
+            parser.AddAssemblyDependency(Assembly.GetEntryAssembly(), true);
+            parser.Parse(Array.Empty<string>(), path);
+
+            return parser.GetGenerator();
+        }
     }
 
     public void AddAssembly(Assembly assembly) => _assemblies.Add(assembly);

--- a/src/Compiler.Dynamic/WebFormsCompilationService.cs
+++ b/src/Compiler.Dynamic/WebFormsCompilationService.cs
@@ -1,7 +1,9 @@
 // MIT License.
 
+using Microsoft.Extensions.FileProviders;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
 using Microsoft.Extensions.Primitives;
 
 namespace WebForms.Compiler.Dynamic;
@@ -11,12 +13,15 @@ internal sealed class WebFormsCompilationService : BackgroundService
     private readonly ILogger<WebFormsCompilationService> _logger;
     private readonly ManualResetEventSlim _event;
     private readonly IWebFormsCompiler _compiler;
+    private readonly IOptions<PageCompilationOptions> _options;
 
     public WebFormsCompilationService(
         IWebFormsCompiler compiler,
+        IOptions<PageCompilationOptions> options,
         ILogger<WebFormsCompilationService> logger)
     {
         _compiler = compiler;
+        _options = options;
         _logger = logger;
         _event = new ManualResetEventSlim(true);
     }
@@ -31,11 +36,14 @@ internal sealed class WebFormsCompilationService : BackgroundService
     {
         var files = _compiler.Files;
 
-        using (ChangeToken.OnChange(() => files.Watch("**/*.aspx*"), OnFileChange))
-        using (ChangeToken.OnChange(() => files.Watch("**/*.Master*"), OnFileChange))
+        using var matcher = new CompositeWatcher(files, OnFileChange);
+
+        foreach (var extension in _options.Value.Parsers.Keys)
         {
-            await ProcessChanges(stoppingToken).ConfigureAwait(false);
+            matcher.AddExtension(extension);
         }
+
+        await ProcessChanges(stoppingToken).ConfigureAwait(false);
     }
 
     private void OnFileChange()
@@ -53,6 +61,27 @@ internal sealed class WebFormsCompilationService : BackgroundService
             await _compiler.CompilePagesAsync(token).ConfigureAwait(false);
 
             _event.Reset();
+        }
+    }
+
+    private sealed class CompositeWatcher(IFileProvider files, Action action) : IDisposable
+    {
+        private readonly List<IDisposable> _disposables = [];
+
+        public void AddExtension(string extension)
+        {
+            var disposable = ChangeToken.OnChange(() => files.Watch($"**/*{extension}*"), action);
+
+            _disposables.Add(disposable);
+        }
+
+
+        public void Dispose()
+        {
+            foreach (var d in _disposables)
+            {
+                d.Dispose();
+            }
         }
     }
 }

--- a/src/Compiler.Dynamic/WebFormsCompilerExtensions.cs
+++ b/src/Compiler.Dynamic/WebFormsCompilerExtensions.cs
@@ -37,6 +37,12 @@ public static class WebFormsCompilerExtensions
             .Configure<IHostEnvironment>((options, env) =>
             {
                 options.Files = env.ContentRootFileProvider;
+
+                options.AddParser<PageParser>(".aspx");
+                options.AddParser<MasterPageParser>(".Master");
+
+                //TODO https://github.com/twsouthwick/systemweb-adapters-ui/issues/19 , keeping the code to tackle in next CR
+                //options.AddParser<UserControlParser>(".ascx");
             })
             .Configure(configure);
 

--- a/src/WebForms/Compilation/BaseTemplateParser.cs
+++ b/src/WebForms/Compilation/BaseTemplateParser.cs
@@ -13,7 +13,6 @@ using System.Collections;
 using System.ComponentModel.Design;
 using System.Diagnostics;
 using System.Web.Util;
-using HttpException = System.Web.HttpException;
 
 /*
  * Parser for Template Files (TemplateControls and PageTheme)

--- a/src/WebForms/Compilation/TemplateParser.cs
+++ b/src/WebForms/Compilation/TemplateParser.cs
@@ -60,6 +60,10 @@ public class CompilationSection
 public abstract class TemplateParser : BaseParser, IAssemblyDependencyParser
 {
 
+    internal abstract BaseCodeDomTreeGenerator GetGenerator();
+
+    internal virtual IEnumerable<string> GetDependencyPaths() => [];
+
     internal const string CodeFileBaseClassAttributeName = "codefilebaseclass";
 
     // The <compilation> config section

--- a/src/WebForms/UI/MasterPageParser.cs
+++ b/src/WebForms/UI/MasterPageParser.cs
@@ -11,6 +11,7 @@ namespace System.Web.UI;
 using System;
 using System.Collections;
 using System.Web;
+using System.Web.Compilation;
 using System.Web.Util;
 
 /*
@@ -51,6 +52,8 @@ internal sealed class MasterPageParser : UserControlParser
             return _placeHolderList;
         }
     }
+
+    internal override BaseCodeDomTreeGenerator GetGenerator() => new MasterPageCodeDomTreeGenerator(this);
 
     // Do not apply the basetype. Override this method
     // so the userControlbasetype do not affect masterpages.

--- a/src/WebForms/UI/PageParser.cs
+++ b/src/WebForms/UI/PageParser.cs
@@ -55,8 +55,10 @@ public sealed class PageParser : TemplateControlParser
     {
         if (MasterPage is { Path: { } masterPath })
         {
-            yield return masterPath;
+            return [masterPath, .. base.GetDependencyPaths()];
         }
+
+        return base.GetDependencyPaths();
     }
 
     private readonly TraceMode _traceMode = System.Web.TraceMode.Default;

--- a/src/WebForms/UI/PageParser.cs
+++ b/src/WebForms/UI/PageParser.cs
@@ -10,8 +10,10 @@ namespace System.Web.UI;
 
 using System;
 using System.Collections;
+using System.Collections.Generic;
 using System.IO;
 using System.Text;
+using System.Web.Compilation;
 using System.Web.Configuration;
 using System.Web.Util;
 
@@ -46,6 +48,16 @@ public sealed class PageParser : TemplateControlParser
 #else
     internal static int TransactionMode => 0;
 #endif
+
+    internal override BaseCodeDomTreeGenerator GetGenerator() => new PageCodeDomTreeGenerator(this);
+
+    internal override IEnumerable<string> GetDependencyPaths()
+    {
+        if (MasterPage is { Path: { } masterPath })
+        {
+            yield return masterPath;
+        }
+    }
 
     private readonly TraceMode _traceMode = System.Web.TraceMode.Default;
     internal TraceMode TraceMode { get { return _traceMode; } }

--- a/src/WebForms/UI/PageThemeParser.cs
+++ b/src/WebForms/UI/PageThemeParser.cs
@@ -5,6 +5,7 @@ namespace System.Web.UI;
 using System;
 using System.Collections;
 using System.Text;
+using System.Web.Compilation;
 using System.Web.Util;
 
 internal class PageThemeParser : BaseTemplateParser
@@ -28,6 +29,8 @@ internal class PageThemeParser : BaseTemplateParser
         _skinFileList = skinFileList;
         _cssFileList = cssFileList;
     }
+
+    internal override BaseCodeDomTreeGenerator GetGenerator() => new PageThemeCodeDomTreeGenerator(this);
 
     internal ICollection CssFileList
     {

--- a/src/WebForms/UI/UserControlParser.cs
+++ b/src/WebForms/UI/UserControlParser.cs
@@ -10,6 +10,7 @@ namespace System.Web.UI;
 
 using System;
 using System.Collections;
+using System.Web.Compilation;
 
 /*
  * Parser for declarative controls
@@ -25,6 +26,8 @@ internal class UserControlParser : TemplateControlParser
     internal static bool FSharedPartialCaching => false;
     internal static string Provider => null;
 #endif
+
+    internal override BaseCodeDomTreeGenerator GetGenerator() => new UserControlCodeDomTreeGenerator(this);
 
     // Get default settings from config
     internal override void ProcessConfigSettings()


### PR DESCRIPTION
This allows the parser to control more of the logic for things such as generating code and identifying dependencies. To add a new "parser" now just requires registering it in the PageCompilationOptions