### PR TITLE
Don't buffer respose when an HttpApplication is registered

### DIFF
--- a/src/Handlers/HandlerServicesExtensions.cs
+++ b/src/Handlers/HandlerServicesExtensions.cs
@@ -1,5 +1,6 @@
 // MIT License.
 
+using System.Web;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.SystemWebAdapters;
@@ -14,6 +15,8 @@ public static class HandlerServicesExtensions
     {
         services.Services.TryAddSingleton<IHttpHandlerEndpointFactory, HttpHandlerEndpointFactory>();
         services.Services.AddTransient<IStartupFilter, HttpHandlerStartupFilter>();
+        services.Services.AddTransient<HandlerMetadataProvider>();
+        services.Services.AddTransient<HttpHandlerEndpointConventionBuilder>();
 
         return services;
     }

--- a/src/Handlers/HttpHandlerEndpointFactory.cs
+++ b/src/Handlers/HttpHandlerEndpointFactory.cs
@@ -8,7 +8,7 @@ using Microsoft.AspNetCore.Routing;
 
 namespace Microsoft.AspNetCore.SystemWebAdapters.HttpHandlers;
 
-internal sealed class HttpHandlerEndpointFactory : IHttpHandlerEndpointFactory
+internal sealed class HttpHandlerEndpointFactory(HandlerMetadataProvider metadataProvider) : IHttpHandlerEndpointFactory
 {
     // Used to ensure we only create a single endpoint instance for a given handler. However,
     // we don't have a way to track when a handler ceases to exist, so we use the
@@ -34,12 +34,12 @@ internal sealed class HttpHandlerEndpointFactory : IHttpHandlerEndpointFactory
         return newEndpoint;
     }
 
-    private static Endpoint Create(IHttpHandler handler)
+    private Endpoint Create(IHttpHandler handler)
     {
         var builder = new NonRouteEndpointBuilder();
         var metadata = HandlerMetadata.Create("/", handler);
 
-        HttpHandlerEndpointConventionBuilder.AddHttpHandlerMetadata(builder, metadata);
+        metadataProvider.Add(builder, metadata);
 
         return builder.Build();
     }

--- a/src/Handlers/SystemWeb/HandlerMetadataProvider.cs
+++ b/src/Handlers/SystemWeb/HandlerMetadataProvider.cs
@@ -1,0 +1,55 @@
+// MIT License.
+
+using System.Web;
+using System.Web.SessionState;
+using Microsoft.AspNetCore.SystemWebAdapters;
+using Microsoft.AspNetCore.SystemWebAdapters.HttpHandlers;
+using Microsoft.Extensions.Options;
+
+namespace Microsoft.AspNetCore.Builder;
+
+internal sealed class HandlerMetadataProvider
+{
+    private readonly bool _needsResponseBuffering;
+
+    public HandlerMetadataProvider(IOptions<HttpApplicationOptions> options)
+    {
+        var custom = options.Value.ApplicationType != typeof(HttpApplication);
+        var hasModules = options.Value.Modules.Count > 0;
+
+        _needsResponseBuffering = !custom || hasModules;
+    }
+
+    private static class Metadata
+    {
+        public static object BufferResponse = new BufferResponseStreamAttribute();
+        public static object BufferRequest = new PreBufferRequestStreamAttribute();
+        public static object Principal = new SetThreadCurrentPrincipalAttribute();
+
+        public static object ReadOnlySession = new SessionAttribute { SessionBehavior = SessionStateBehavior.ReadOnly };
+        public static object RequiredSession = new SessionAttribute { SessionBehavior = SessionStateBehavior.Required };
+    }
+
+    public void Add(EndpointBuilder builder, IHttpHandlerMetadata metadata)
+    {
+        if (metadata.Behavior is SessionStateBehavior.ReadOnly)
+        {
+            builder.Metadata.Add(Metadata.ReadOnlySession);
+        }
+        else if (metadata.Behavior is SessionStateBehavior.Required)
+        {
+            builder.Metadata.Add(Metadata.RequiredSession);
+        };
+
+        builder.Metadata.Add(metadata);
+
+        builder.Metadata.Add(Metadata.Principal);
+        builder.Metadata.Add(Metadata.BufferRequest);
+
+        // A bug in the adapters fails to enable buffering if it is already buffered
+        if (_needsResponseBuffering)
+        {
+            builder.Metadata.Add(Metadata.BufferResponse);
+        }
+    }
+}

--- a/src/Handlers/SystemWeb/HttpHandlerBuilderExtensions.cs
+++ b/src/Handlers/SystemWeb/HttpHandlerBuilderExtensions.cs
@@ -23,8 +23,7 @@ public static class HttpHandlerBuilderExtensions
     {
         if (endpoints.DataSources.OfType<HttpHandlerEndpointConventionBuilder>().FirstOrDefault() is not { } existing)
         {
-            var managers = endpoints.ServiceProvider.GetService<IEnumerable<IHttpHandlerCollection>>();
-            existing = new HttpHandlerEndpointConventionBuilder(managers ?? []);
+            existing = endpoints.ServiceProvider.GetRequiredService<HttpHandlerEndpointConventionBuilder>();
             endpoints.DataSources.Add(existing);
         }
 


### PR DESCRIPTION
This is a bug in the adapters, but we can work around it by only doing the response buffering when the HttpApplication isn't registered.
