### PR TITLE
Ensure Respone.End throws during page execution

### DIFF
--- a/src/Handlers/SystemWeb/RequestEndExtensions.cs
+++ b/src/Handlers/SystemWeb/RequestEndExtensions.cs
@@ -17,7 +17,7 @@ internal static class RequestEndExtensions
     public static IApplicationBuilder EnsureRequestEndThrows(this IApplicationBuilder app)
         => app.Use(async (ctx, next) =>
         {
-            var feature = new RequestThrowingEndFeature(ctx);
+            var feature = new RequestEndThrowingFeature(ctx);
 
             ctx.Features.Set<IHttpResponseEndFeature>(feature);
 
@@ -33,13 +33,13 @@ internal static class RequestEndExtensions
             }
         });
 
-    private sealed class RequestThrowingEndFeature : IHttpResponseEndFeature, IAsyncDisposable
+    private sealed class RequestEndThrowingFeature : IHttpResponseEndFeature, IAsyncDisposable
     {
         private readonly HttpContextCore _context;
         private readonly IHttpResponseEndFeature _original;
         private bool _end;
 
-        public RequestThrowingEndFeature(HttpContextCore context)
+        public RequestEndThrowingFeature(HttpContextCore context)
         {
             _context = context;
             _original = context.Features.GetRequiredFeature<IHttpResponseEndFeature>();

--- a/src/Handlers/SystemWeb/RequestEndExtensions.cs
+++ b/src/Handlers/SystemWeb/RequestEndExtensions.cs
@@ -1,0 +1,70 @@
+// MIT License.
+
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.SystemWebAdapters;
+using Microsoft.AspNetCore.SystemWebAdapters.Features;
+
+namespace System.Web;
+
+#pragma warning disable SYSWEB1001 // Type is for evaluation purposes only and is subject to change or removal in future updates. Suppress this diagnostic to proceed.
+
+internal static class RequestEndExtensions
+{
+    /// <summary>
+    /// By design, the System.Web adapters try not to throw when <see cref="HttpResponse.End"/> but rather tracks it in other ways.
+    /// However, WebForms was built with that expectation and some common scenarios (such as postback calls) break without this.
+    /// </summary>
+    public static IApplicationBuilder EnsureRequestEndThrows(this IApplicationBuilder app)
+        => app.Use(async (ctx, next) =>
+        {
+            var feature = new RequestThrowingEndFeature(ctx);
+
+            ctx.Features.Set<IHttpResponseEndFeature>(feature);
+
+            try
+            {
+                await using (feature)
+                {
+                    await next(ctx).ConfigureAwait(false);
+                }
+            }
+            catch (RequestEndException)
+            {
+            }
+        });
+
+    private sealed class RequestThrowingEndFeature : IHttpResponseEndFeature, IAsyncDisposable
+    {
+        private readonly HttpContextCore _context;
+        private readonly IHttpResponseEndFeature _original;
+        private bool _end;
+
+        public RequestThrowingEndFeature(HttpContextCore context)
+        {
+            _context = context;
+            _original = context.Features.GetRequiredFeature<IHttpResponseEndFeature>();
+        }
+
+        public bool IsEnded => _end || _original.IsEnded;
+
+        public Task EndAsync()
+        {
+            _end = true;
+            throw new RequestEndException();
+        }
+
+        async ValueTask IAsyncDisposable.DisposeAsync()
+        {
+            _context.Features.Set(_original);
+
+            if (_end)
+            {
+                await _original.EndAsync().ConfigureAwait(false);
+            }
+        }
+    }
+
+    private sealed class RequestEndException : Exception
+    {
+    }
+}

--- a/test/Compiler.Dynamic.Tests/DynamicCompilationTests.cs
+++ b/test/Compiler.Dynamic.Tests/DynamicCompilationTests.cs
@@ -66,10 +66,6 @@ public class DynamicCompilationTests
                     RouteTable.Routes.MapPageRoute("Test", "/test", pages[0]);
 
                     app.UseRouting();
-                    app.Use((ctx, next) =>
-                    {
-                        return next(ctx);
-                    });
                     app.UseSession();
                     app.UseSystemWebAdapters();
                     app.UseEndpoints(endpoints =>

--- a/test/Compiler.Dynamic.Tests/DynamicCompilationTests.cs
+++ b/test/Compiler.Dynamic.Tests/DynamicCompilationTests.cs
@@ -1,6 +1,7 @@
 // MIT License.
 
 using System.Diagnostics;
+using System.Net;
 using System.Web.Routing;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;
@@ -30,6 +31,7 @@ public class DynamicCompilationTests
     [DataRow("test04", "page_with_master.aspx", "other_page_with_master.aspx", "page_with_master.aspx")]
     [DataRow("test05", "error_page.aspx")]
     [DataRow("test06", "route_url_expressionbuilder.aspx")]
+    [DataRow("test07", "redirect_page.aspx")]
     public async Task CompiledPageRuns(string test, params string[] pages)
     {
         // Arrange
@@ -64,6 +66,10 @@ public class DynamicCompilationTests
                     RouteTable.Routes.MapPageRoute("Test", "/test", pages[0]);
 
                     app.UseRouting();
+                    app.Use((ctx, next) =>
+                    {
+                        return next(ctx);
+                    });
                     app.UseSession();
                     app.UseSystemWebAdapters();
                     app.UseEndpoints(endpoints =>
@@ -92,12 +98,17 @@ public class DynamicCompilationTests
             var page = pages[i];
 
             string? result = null;
+            var currentPage = page;
 
             do
             {
-                using var response = await client.GetAsync(page, cts.Token);
+                using var response = await client.GetAsync(currentPage, cts.Token);
 
-                if (response.IsSuccessStatusCode)
+                if (response.StatusCode == HttpStatusCode.Found)
+                {
+                    currentPage = response.Headers.Location!.ToString();
+                }
+                else if (response.IsSuccessStatusCode)
                 {
                     result = await response.Content.ReadAsStringAsync();
                 }

--- a/test/Compiler.Dynamic.Tests/assets/test07/actual.aspx
+++ b/test/Compiler.Dynamic.Tests/assets/test07/actual.aspx
@@ -1,0 +1,3 @@
+<%@ Page Title="Home Page" Language="C#" AutoEventWireup="true" %> 
+
+Hello from redirected!

--- a/test/Compiler.Dynamic.Tests/assets/test07/redirect_page.aspx
+++ b/test/Compiler.Dynamic.Tests/assets/test07/redirect_page.aspx
@@ -1,0 +1,11 @@
+<%@ Page Title="Home Page" Language="C#" AutoEventWireup="true" %> 
+
+<script runat="server">
+    protected void Page_Load(object sender, EventArgs e)
+    { 
+        Context.Response.Redirect("~/actual.aspx");
+    }
+</script>
+
+Shouldn't show this!
+

--- a/test/Compiler.Dynamic.Tests/assets/test07/redirect_page.aspx._0.html
+++ b/test/Compiler.Dynamic.Tests/assets/test07/redirect_page.aspx._0.html
@@ -1,0 +1,3 @@
+ 
+
+Hello from redirected!

--- a/test/Compiler.Dynamic.Tests/assets/test07/route_url_expressionbuilder.aspx._0.html
+++ b/test/Compiler.Dynamic.Tests/assets/test07/route_url_expressionbuilder.aspx._0.html
@@ -1,3 +1,0 @@
-<a href="/test">
- Create 
-</a>

--- a/test/Compiler.Dynamic.Tests/assets/test07/route_url_expressionbuilder.aspx._0.html
+++ b/test/Compiler.Dynamic.Tests/assets/test07/route_url_expressionbuilder.aspx._0.html
@@ -1,0 +1,3 @@
+<a href="/test">
+ Create 
+</a>


### PR DESCRIPTION
By design, System.Web adapters do not throw when Response.End occurs, but Pages expect that to occur to stop interaction. An example where this expectation fails is during Response.Redirect calls and the error is difficult to understand. This overrides the End() behavior for the duration of the page execution to ensure the behavior is closer to framework.
