### PR TITLE
Add a banned API for drawing types

### DIFF
--- a/BannedSymbols.txt
+++ b/BannedSymbols.txt
@@ -1,0 +1,1 @@
+T:System.Drawing.ToolboxBitmapAttribute

--- a/CoreWebForms.sln
+++ b/CoreWebForms.sln
@@ -7,6 +7,10 @@ EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "WebForms", "src\WebForms\WebForms.csproj", "{5020FD4F-BA42-4057-8D3F-66A0AB233895}"
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "src", "src", "{D3D2945C-76BA-4DE3-90D2-259E2B1406C5}"
+	ProjectSection(SolutionItems) = preProject
+		src\Directory.Build.props = src\Directory.Build.props
+		src\Directory.Build.targets = src\Directory.Build.targets
+	EndProjectSection
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Handlers", "src\Handlers\Handlers.csproj", "{A8FC25D7-17C3-4822-955B-C2E5426C87BB}"
 EndProject
@@ -20,6 +24,7 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "samples", "samples", "{97FC
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{ED177FFB-95F7-4040-8984-98A667711A55}"
 	ProjectSection(SolutionItems) = preProject
+		BannedSymbols.txt = BannedSymbols.txt
 		Directory.Build.props = Directory.Build.props
 		Directory.Build.targets = Directory.Build.targets
 		global.json = global.json

--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -1,1 +1,11 @@
-<Project />
+<Project>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.CodeAnalysis.BannedApiAnalyzers" Version="3.11.0-beta1.23525.2">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+    <AdditionalFiles Include="$(MSBuildThisFileDirectory)BannedSymbols.txt" />
+  </ItemGroup>
+
+</Project>

--- a/src/Extensions/UI/WebControls/DataPager.cs
+++ b/src/Extensions/UI/WebControls/DataPager.cs
@@ -3,7 +3,6 @@
 using System.Collections;
 using System.ComponentModel;
 using System.Diagnostics.CodeAnalysis;
-using System.Drawing;
 using System.Globalization;
 using System.Text;
 using System.Web.Resources;
@@ -16,7 +15,9 @@ PersistChildren(false),
 Themeable(true),
 SupportsEventValidation,
 Designer("System.Web.UI.Design.WebControls.DataPagerDesigner, " + AssemblyRef.SystemWebExtensionsDesign),
+#if PORT_SYSTEMDRAWING
 ToolboxBitmap(typeof(DataPager), "DataPager.bmp")
+#endif
 ]
 public class DataPager : Control, IAttributeAccessor, INamingContainer, ICompositeControlDesignerAccessor
 {

--- a/src/Extensions/UI/WebControls/ListView.cs
+++ b/src/Extensions/UI/WebControls/ListView.cs
@@ -17,7 +17,9 @@ namespace System.Web.UI.WebControls;
 [ControlValueProperty("SelectedValue")]
 [DefaultEvent("SelectedIndexChanged")]
 [SupportsEventValidation]
+#if PORT_SYSTEMDRAWING
 [ToolboxBitmap(typeof(ListView), "ListView.bmp")]
+#endif
 [DataKeyProperty("SelectedPersistedDataKey")]
 public class ListView : DataBoundControl, INamingContainer, IPageableItemContainer, IPersistedSelector, IDataKeysControl, IDataBoundListControl, IWizardSideBarListControl
 {

--- a/src/WebForms/WebForms.csproj
+++ b/src/WebForms/WebForms.csproj
@@ -32,7 +32,6 @@
     <PackageReference Include="System.CodeDom" Version="8.0.0" />
     <PackageReference Include="Microsoft.AspNetCore.SystemWebAdapters" Version="1.3.2" />
     <PackageReference Include="Microsoft.AspNetCore.SystemWebAdapters.CoreServices" Version="1.3.2" />
-    <PackageReference Include="System.Drawing.Common" Version="8.0.1" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
We're ok using System.Drawing.Primitives (where color is), but System.Drawing.Common is not available on all platforms. However, the sdk seems to allow us to reference it and then it breaks at runtime. This adds a BannedSymbols.txt so that we can add to it for the APIs we find that are using that assembly; unfortunately, we can't just disable all System.Drawing, as then color is not allowed.
