### PR TITLE
Create CompileType in a consistent way

### DIFF
--- a/src/WebForms/Compilation/CompilationUtil.cs
+++ b/src/WebForms/Compilation/CompilationUtil.cs
@@ -21,11 +21,13 @@ internal static class CompilationUtil
 
     internal static CompilerType GetDefaultLanguageCompilerInfo(CompilationSection compConfig, VirtualPath configPath)
     {
+#if PORT_CONFIG
         if (compConfig == null)
         {
             // Get the <compilation> config object
             compConfig = MTConfigUtil.GetCompilationConfig(configPath);
         }
+#endif
 
         // If no default language was specified in config, use VB
         if (compConfig.DefaultLanguage == null)
@@ -34,7 +36,7 @@ internal static class CompilationUtil
         }
         else
         {
-            return compConfig.GetCompilerInfoFromLanguage(compConfig.DefaultLanguage);
+            return CompilerType.Create(compConfig.DefaultLanguage);
         }
     }
 
@@ -43,7 +45,6 @@ internal static class CompilationUtil
      */
     internal static CompilerType GetCompilerInfoFromVirtualPath(VirtualPath virtualPath)
     {
-
         // Get the extension of the source file to compile
         string extension = virtualPath.Extension;
 
@@ -54,44 +55,7 @@ internal static class CompilationUtil
                 SR.GetString(SR.Empty_extension, virtualPath));
         }
 
-        return GetCompilerInfoFromExtension(virtualPath, extension);
-    }
-
-    /*
-     * Return a CompilerType that a extension maps to.
-     */
-    private static CompilerType GetCompilerInfoFromExtension(VirtualPath configPath, string extension)
-    {
-        return CompilationSection.GetCompilerInfoFromExtension(extension, true /*throwOnFail*/);
-    }
-
-    /*
-     * Return a CompilerType that a language maps to.
-     */
-    internal static CompilerType GetCompilerInfoFromLanguage(VirtualPath configPath, string language)
-    {
-        // Get the <compilation> config object
-        CompilationSection config = MTConfigUtil.GetCompilationConfig(configPath);
-
-        return config.GetCompilerInfoFromLanguage(language);
-    }
-
-    internal static CompilerType GetCSharpCompilerInfo(
-        CompilationSection compConfig, VirtualPath configPath)
-    {
-
-        if (compConfig == null)
-        {
-            // Get the <compilation> config object
-            compConfig = MTConfigUtil.GetCompilationConfig(configPath);
-        }
-
-        if (compConfig.DefaultLanguage == null)
-        {
-            return CompilerType.CSharp;
-        }
-
-        return compConfig.GetCompilerInfoFromLanguage("c#");
+        return CompilerType.GetByExtension(extension);
     }
 
 #if PORT_SUBDIRECTORIES

--- a/src/WebForms/Compilation/CompilerTypeWithParams.cs
+++ b/src/WebForms/Compilation/CompilerTypeWithParams.cs
@@ -27,6 +27,23 @@ public sealed class CompilerType
 
     public bool IsVisualBasic() => string.Equals("VB", Language, StringComparison.OrdinalIgnoreCase);
 
+    public static CompilerType Create(string language)
+    {
+        if (string.Equals(language, "C#", StringComparison.OrdinalIgnoreCase))
+        {
+            return CSharp;
+        }
+        else
+        if (string.Equals(language, "VB", StringComparison.OrdinalIgnoreCase))
+        {
+            return VisualBasic;
+        }
+        else
+        {
+            return new CompilerType(language, null);
+        }
+    }
+
     public static CompilerType GetByExtension(string extension)
     {
         if (string.Equals(".cs", extension, StringComparison.OrdinalIgnoreCase))

--- a/src/WebForms/Compilation/TemplateParser.cs
+++ b/src/WebForms/Compilation/TemplateParser.cs
@@ -40,20 +40,8 @@ public class CompilationSection
     public bool Batch { get; internal set; }
     public int NumRecompilesBeforeAppRestart { get; internal set; }
     public string DefaultLanguage { get; internal set; }
-    public bool Debug { get; internal set; }
+    public bool Debug { get; internal set; } = true;
     public bool UrlLinePragmas { get; internal set; }
-
-    internal static CompilerType GetCompilerInfoFromExtension(string extension, bool v) => CompilerType.GetByExtension(extension);
-
-    internal CompilerType GetCompilerInfoFromLanguage(string language) => new(language, new()
-    {
-        IncludeDebugInformation = Debug,
-    });
-
-    internal Assembly LoadAssembly(string assemblyName, bool throwOnFail)
-    {
-        throw new NotImplementedException("LoadAssembly");
-    }
 }
 
 /// <internalonly/>
@@ -2543,8 +2531,7 @@ private Match RunTextRegex(string text, int textPos) {
             return;
         }
 
-        CompilerType compilerType = CompilationUtil.GetCompilerInfoFromLanguage(
-            CurrentVirtualPath, language);
+        CompilerType compilerType = CompilerType.Create(language);
 
         // Make sure we don't get conflicting languages
         if (_compilerType != null && !Equals(_compilerType, compilerType))


### PR DESCRIPTION
There were two pathways to create compile type that caused different configurations to be created and would cause compile errors. This unifies those pathways so we get a consistent value.

Part of https://github.com/CoreWebForms/Samples/issues/6
