### PR TITLE
Enable configuration of file provider used by compilation service

### DIFF
--- a/src/Compiler.Dynamic/DynamicSystemWebCompilation.cs
+++ b/src/Compiler.Dynamic/DynamicSystemWebCompilation.cs
@@ -31,8 +31,9 @@ internal sealed class DynamicSystemWebCompilation : SystemWebCompilation<Dynamic
         ILoggerFactory factory,
         IHostEnvironment env,
         IMetadataProvider metadataProvider,
-        IOptions<PageCompilationOptions> options)
-        : base(env, factory, metadataProvider, options)
+        IOptions<WebFormsOptions> webFormsOptions,
+        IOptions<PageCompilationOptions> pageCompilationOptions)
+        : base(env, factory, metadataProvider, webFormsOptions, pageCompilationOptions)
     {
         _logger = factory.CreateLogger<DynamicSystemWebCompilation>();
         _factory = factory;

--- a/src/Compiler.Dynamic/PageCompilationOptions.cs
+++ b/src/Compiler.Dynamic/PageCompilationOptions.cs
@@ -1,8 +1,10 @@
 // MIT License.
 
 using System.Reflection;
+using System.Web;
 using System.Web.Compilation;
 using System.Web.UI;
+using Microsoft.Extensions.FileProviders;
 
 namespace WebForms.Compiler.Dynamic;
 
@@ -13,6 +15,7 @@ public class PageCompilationOptions
     }
 
     public bool IsDebug { get; set; }
+    internal IFileProvider WebFormsFileProvider { get; set; } = default!;
 
     internal Dictionary<string, Func<string, BaseCodeDomTreeGenerator>> Parsers { get; } = new(StringComparer.OrdinalIgnoreCase);
 
@@ -21,10 +24,11 @@ public class PageCompilationOptions
     {
         Parsers.Add(extension, Create);
 
-        static BaseCodeDomTreeGenerator Create(string path)
+        BaseCodeDomTreeGenerator Create(string path)
         {
             var parser = new TParser();
 
+            parser.WebFormsFileProvider = WebFormsFileProvider;
             parser.AddAssemblyDependency(Assembly.GetEntryAssembly(), true);
             parser.Parse(Array.Empty<string>(), path);
 

--- a/src/Compiler.Dynamic/StaticSystemWebCompilation.cs
+++ b/src/Compiler.Dynamic/StaticSystemWebCompilation.cs
@@ -2,6 +2,7 @@
 
 using System.Reflection;
 using System.Text.Json;
+using System.Web;
 using Microsoft.CodeAnalysis;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
@@ -14,18 +15,21 @@ namespace WebForms.Compiler.Dynamic;
 internal sealed class StaticSystemWebCompilation : SystemWebCompilation<PersistedCompiledPage>, IWebFormsCompiler
 {
     private readonly IOptions<StaticCompilationOptions> _options;
+    private readonly IOptions<PageCompilationOptions> _pageCompilationOptions;
     private readonly ILogger _logger;
 
     public StaticSystemWebCompilation(
         IHostEnvironment env,
         IOptions<StaticCompilationOptions> options,
-        IOptions<PageCompilationOptions> pageOptions,
+        IOptions<WebFormsOptions> webFormsOptions,
+        IOptions<PageCompilationOptions> pageCompilationOptions,
         IMetadataProvider metadataProvider,
         ILoggerFactory factory)
-        : base(env, factory, metadataProvider, pageOptions)
+        : base(env, factory, metadataProvider, webFormsOptions, pageCompilationOptions)
     {
         _logger = factory.CreateLogger<StaticSystemWebCompilation>();
         _options = options;
+        _pageCompilationOptions = pageCompilationOptions;
     }
 
     protected override PersistedCompiledPage CreateCompiledPage(

--- a/src/Compiler.Dynamic/SystemWebCompilation.cs
+++ b/src/Compiler.Dynamic/SystemWebCompilation.cs
@@ -80,7 +80,7 @@ internal abstract class SystemWebCompilation<T> : IDisposable
         });
     }
 
-    public IFileProvider Files => _env.ContentRootFileProvider;
+    public IFileProvider Files => VirtualPath.Files ?? _env.ContentRootFileProvider;
 
     protected void RemovePage(string path) => _compiled.Remove(path);
 

--- a/src/Compiler.Dynamic/SystemWebCompilation.cs
+++ b/src/Compiler.Dynamic/SystemWebCompilation.cs
@@ -28,7 +28,8 @@ internal abstract class SystemWebCompilation<T> : IDisposable
     private readonly ICompiler _vb;
     private readonly IMetadataProvider _metadata;
     private readonly ILogger<SystemWebCompilation<T>> _logger;
-    private readonly IOptions<PageCompilationOptions> _pageCompilation;
+    private readonly IOptions<WebFormsOptions> _webFormsOptions;
+    private readonly IOptions<PageCompilationOptions> _pageCompilationOptions;
 
     private Dictionary<string, Task<T>> _compiled = [];
 
@@ -36,17 +37,19 @@ internal abstract class SystemWebCompilation<T> : IDisposable
         IHostEnvironment env,
         ILoggerFactory logger,
         IMetadataProvider metadata,
-        IOptions<PageCompilationOptions> pageCompilation)
+        IOptions<WebFormsOptions> webFormsOptions,
+        IOptions<PageCompilationOptions> pageCompilationOptions)
     {
         _env = env;
-        _csharp = new CSharpCompiler(pageCompilation.Value);
-        _vb = new VisualBasicCompiler(pageCompilation.Value);
+        _csharp = new CSharpCompiler(pageCompilationOptions.Value);
+        _vb = new VisualBasicCompiler(pageCompilationOptions.Value);
 
         _metadata = metadata;
         _logger = logger.CreateLogger<SystemWebCompilation<T>>();
-        _pageCompilation = pageCompilation;
+        _webFormsOptions = webFormsOptions;
+        _pageCompilationOptions = pageCompilationOptions;
 
-        _logger.LogInformation("Compiler set to IsDebug={IsDebug}", pageCompilation.Value.IsDebug);
+        _logger.LogInformation("Compiler set to IsDebug={IsDebug}", pageCompilationOptions.Value.IsDebug);
     }
 
     protected IEnumerable<T> GetPages()
@@ -80,7 +83,7 @@ internal abstract class SystemWebCompilation<T> : IDisposable
         });
     }
 
-    public IFileProvider Files => VirtualPath.Files ?? _env.ContentRootFileProvider;
+    public IFileProvider Files => _webFormsOptions.Value.WebFormsFileProvider ?? _env.ContentRootFileProvider;
 
     protected void RemovePage(string path) => _compiled.Remove(path);
 
@@ -228,7 +231,7 @@ internal abstract class SystemWebCompilation<T> : IDisposable
     {
         var extension = Path.GetExtension(path);
 
-        if (_pageCompilation.Value.Parsers.TryGetValue(extension, out var parser))
+        if (_pageCompilationOptions.Value.Parsers.TryGetValue(extension, out var parser))
         {
             return parser(path);
         }

--- a/src/Compiler.Dynamic/SystemWebCompilation.cs
+++ b/src/Compiler.Dynamic/SystemWebCompilation.cs
@@ -83,7 +83,7 @@ internal abstract class SystemWebCompilation<T> : IDisposable
         });
     }
 
-    public IFileProvider Files => _webFormsOptions.Value.WebFormsFileProvider ?? _env.ContentRootFileProvider;
+    public IFileProvider Files => _webFormsOptions.Value.WebFormsFileProvider;
 
     protected void RemovePage(string path) => _compiled.Remove(path);
 

--- a/src/Compiler.Dynamic/WebFormsCompilerExtensions.cs
+++ b/src/Compiler.Dynamic/WebFormsCompilerExtensions.cs
@@ -2,12 +2,14 @@
 
 using System.ComponentModel.Design;
 using System.Reflection;
+using System.Web;
 using System.Web.UI;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.SystemWebAdapters.HttpHandlers;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Options;
+using WebForms;
 using WebForms.Compiler.Dynamic;
 
 namespace Microsoft.Extensions.DependencyInjection;
@@ -46,8 +48,9 @@ public static class WebFormsCompilerExtensions
     private static void AddWebFormsCompilationCore(this IServiceCollection services, Action<PageCompilationOptions> configure)
     {
         services.AddOptions<PageCompilationOptions>()
-            .Configure(options =>
+            .Configure<IOptions<WebFormsOptions>>((options, webFormsOptions) =>
             {
+                options.WebFormsFileProvider = webFormsOptions.Value.WebFormsFileProvider;
                 options.AddParser<PageParser>(".aspx");
                 options.AddParser<MasterPageParser>(".Master");
 

--- a/src/VirtualFile/VirtualPath.cs
+++ b/src/VirtualFile/VirtualPath.cs
@@ -11,7 +11,12 @@ namespace System.Web;
 
 internal sealed class VirtualPath
 {
-    private static IFileProvider Files => HttpRuntimeHelper.Services.GetRequiredService<IHostEnvironment>().ContentRootFileProvider;
+    private static IFileProvider _fileProvider;
+    internal static IFileProvider Files
+    {
+        get => _fileProvider ??= HttpRuntimeHelper.Services.GetRequiredService<IHostEnvironment>().ContentRootFileProvider;
+        set => _fileProvider = value;
+    }
 
     public VirtualPath Parent
     {

--- a/src/VirtualFile/VirtualPath.cs
+++ b/src/VirtualFile/VirtualPath.cs
@@ -11,12 +11,7 @@ namespace System.Web;
 
 internal sealed class VirtualPath
 {
-    private static IFileProvider _fileProvider;
-    internal static IFileProvider Files
-    {
-        get => _fileProvider ??= HttpRuntimeHelper.Services.GetRequiredService<IHostEnvironment>().ContentRootFileProvider;
-        set => _fileProvider = value;
-    }
+    private static IFileProvider Files => HttpRuntimeHelper.Services.GetRequiredService<IHostEnvironment>().ContentRootFileProvider;
 
     public VirtualPath Parent
     {

--- a/src/VirtualFile/VirtualPath.cs
+++ b/src/VirtualFile/VirtualPath.cs
@@ -11,7 +11,12 @@ namespace System.Web;
 
 internal sealed class VirtualPath
 {
-    private static IFileProvider Files => HttpRuntimeHelper.Services.GetRequiredService<IHostEnvironment>().ContentRootFileProvider;
+    private IFileProvider _fileProvider;
+    internal IFileProvider Files
+    {
+        get => _fileProvider ??= HttpRuntimeHelper.Services.GetRequiredService<IHostEnvironment>().ContentRootFileProvider;
+        set => _fileProvider = value;
+    }
 
     public VirtualPath Parent
     {
@@ -29,9 +34,11 @@ internal sealed class VirtualPath
             return result + "/";
         }
     }
-    public VirtualPath(string path)
+
+    public VirtualPath(string path, IFileProvider fileProvider = null)
     {
         Path = Resolve(path);
+        _fileProvider = fileProvider;
     }
 
     public static string Resolve(string url)
@@ -145,6 +152,7 @@ internal sealed class VirtualPath
     internal Stream OpenFile() => Files.GetFileInfo(Path).CreateReadStream();
 
     internal static VirtualPath Create(string filename) => filename;
+    internal static VirtualPath Create(string filename, IFileProvider fileProvider) => new(filename, fileProvider);
 
     internal bool FileExists() => Files.GetFileInfo(Path).Exists;
 

--- a/src/VirtualFile/VirtualPath.cs
+++ b/src/VirtualFile/VirtualPath.cs
@@ -11,12 +11,7 @@ namespace System.Web;
 
 internal sealed class VirtualPath
 {
-    private IFileProvider _fileProvider;
-    internal IFileProvider Files
-    {
-        get => _fileProvider ??= HttpRuntimeHelper.Services.GetRequiredService<IHostEnvironment>().ContentRootFileProvider;
-        set => _fileProvider = value;
-    }
+    private static IFileProvider Files => HttpRuntimeHelper.Services.GetRequiredService<IHostEnvironment>().ContentRootFileProvider;
 
     public VirtualPath Parent
     {
@@ -35,10 +30,9 @@ internal sealed class VirtualPath
         }
     }
 
-    public VirtualPath(string path, IFileProvider fileProvider = null)
+    public VirtualPath(string path)
     {
         Path = Resolve(path);
-        _fileProvider = fileProvider;
     }
 
     public static string Resolve(string url)
@@ -149,12 +143,11 @@ internal sealed class VirtualPath
         return value;
     }
 
-    internal Stream OpenFile() => Files.GetFileInfo(Path).CreateReadStream();
+    internal Stream OpenFile(IFileProvider files = null) => (files ?? Files).GetFileInfo(Path).CreateReadStream();
 
     internal static VirtualPath Create(string filename) => filename;
-    internal static VirtualPath Create(string filename, IFileProvider fileProvider) => new(filename, fileProvider);
 
-    internal bool FileExists() => Files.GetFileInfo(Path).Exists;
+    internal bool FileExists(IFileProvider files = null) => (files ?? Files).GetFileInfo(Path).Exists;
 
     internal string MapPath()
     {

--- a/src/VirtualFile/VirtualPath.cs
+++ b/src/VirtualFile/VirtualPath.cs
@@ -11,8 +11,6 @@ namespace System.Web;
 
 internal sealed class VirtualPath
 {
-    private static IFileProvider Files => HttpRuntimeHelper.Services.GetRequiredService<IHostEnvironment>().ContentRootFileProvider;
-
     public VirtualPath Parent
     {
         get
@@ -143,11 +141,11 @@ internal sealed class VirtualPath
         return value;
     }
 
-    internal Stream OpenFile(IFileProvider files = null) => (files ?? Files).GetFileInfo(Path).CreateReadStream();
+    internal Stream OpenFile(IFileProvider fileProvider) => fileProvider.GetFileInfo(Path).CreateReadStream();
 
     internal static VirtualPath Create(string filename) => filename;
 
-    internal bool FileExists(IFileProvider files = null) => (files ?? Files).GetFileInfo(Path).Exists;
+    internal bool FileExists(IFileProvider fileProvider) => fileProvider.GetFileInfo(Path).Exists;
 
     internal string MapPath()
     {

--- a/src/WebForms/Compilation/BaseParser.cs
+++ b/src/WebForms/Compilation/BaseParser.cs
@@ -100,9 +100,6 @@ public partial class BaseParser
      */
     internal VirtualPath ResolveVirtualPath(VirtualPath virtualPath)
     {
-        var newVirtualPath = VirtualPathProvider.CombineVirtualPathsInternal(CurrentVirtualPath, virtualPath);
-        newVirtualPath.Files = virtualPath.Files;
-
-        return newVirtualPath;
+        return VirtualPathProvider.CombineVirtualPathsInternal(CurrentVirtualPath, virtualPath);
     }
 }

--- a/src/WebForms/Compilation/BaseParser.cs
+++ b/src/WebForms/Compilation/BaseParser.cs
@@ -2,6 +2,7 @@
 
 using System.Collections;
 using System.Text.RegularExpressions;
+using Microsoft.Extensions.FileProviders;
 
 /*
  * Implements the ASP.NET template parser
@@ -70,6 +71,8 @@ public partial class BaseParser
         }
     }
 
+    internal IFileProvider WebFormsFileProvider { get; set; } = default!;
+
     internal string CurrentVirtualPathString
     {
         get { return System.Web.VirtualPath.GetVirtualPathString(CurrentVirtualPath); }
@@ -97,6 +100,9 @@ public partial class BaseParser
      */
     internal VirtualPath ResolveVirtualPath(VirtualPath virtualPath)
     {
-        return VirtualPathProvider.CombineVirtualPathsInternal(CurrentVirtualPath, virtualPath);
+        var newVirtualPath = VirtualPathProvider.CombineVirtualPathsInternal(CurrentVirtualPath, virtualPath);
+        newVirtualPath.Files = virtualPath.Files;
+
+        return newVirtualPath;
     }
 }

--- a/src/WebForms/Compilation/BatchParser.cs
+++ b/src/WebForms/Compilation/BatchParser.cs
@@ -240,12 +240,12 @@ internal abstract class DependencyParser : BaseParser
             {
 
                 // If it's relative, just treat it as virtual
-                newVirtualPath = ResolveVirtualPath(VirtualPath.Create(filename));
+                newVirtualPath = ResolveVirtualPath(VirtualPath.Create(filename, WebFormsFileProvider));
             }
         }
         else if (StringUtil.EqualsIgnoreCase(pathType, "virtual"))
         {
-            newVirtualPath = ResolveVirtualPath(VirtualPath.Create(filename));
+            newVirtualPath = ResolveVirtualPath(VirtualPath.Create(filename, WebFormsFileProvider));
         }
         else
         {
@@ -348,7 +348,7 @@ internal abstract class DependencyParser : BaseParser
         if (name == "src")
         {
             string src = Util.GetNonEmptyAttribute(name, value);
-            AddDependency(VirtualPath.Create(src));
+            AddDependency(VirtualPath.Create(src, WebFormsFileProvider));
         }
     }
 
@@ -403,7 +403,7 @@ internal abstract class TemplateControlDependencyParser : DependencyParser
                 if (value.Length > 0)
                 {
                     // Add a dependency on the master, whether it has a device filter or not
-                    AddDependency(VirtualPath.Create(value));
+                    AddDependency(VirtualPath.Create(value, WebFormsFileProvider));
                 }
                 break;
 
@@ -428,7 +428,7 @@ internal class PageDependencyParser : TemplateControlDependencyParser
         {
             if (PagesConfig.MasterPageFileInternal != null && PagesConfig.MasterPageFileInternal.Length != 0)
             {
-                AddDependency(VirtualPath.Create(PagesConfig.MasterPageFileInternal));
+                AddDependency(VirtualPath.Create(PagesConfig.MasterPageFileInternal, WebFormsFileProvider));
             }
         }
     }

--- a/src/WebForms/Compilation/BatchParser.cs
+++ b/src/WebForms/Compilation/BatchParser.cs
@@ -122,7 +122,7 @@ internal abstract class DependencyParser : BaseParser
             }
             else
             {
-                using (Stream stream = virtualPath.OpenFile())
+                using (Stream stream = virtualPath.OpenFile(WebFormsFileProvider))
                 {
                     reader = Util.ReaderFromStream(stream, virtualPath);
                     ParseReader(reader);
@@ -240,12 +240,12 @@ internal abstract class DependencyParser : BaseParser
             {
 
                 // If it's relative, just treat it as virtual
-                newVirtualPath = ResolveVirtualPath(VirtualPath.Create(filename, WebFormsFileProvider));
+                newVirtualPath = ResolveVirtualPath(VirtualPath.Create(filename));
             }
         }
         else if (StringUtil.EqualsIgnoreCase(pathType, "virtual"))
         {
-            newVirtualPath = ResolveVirtualPath(VirtualPath.Create(filename, WebFormsFileProvider));
+            newVirtualPath = ResolveVirtualPath(VirtualPath.Create(filename));
         }
         else
         {
@@ -348,7 +348,7 @@ internal abstract class DependencyParser : BaseParser
         if (name == "src")
         {
             string src = Util.GetNonEmptyAttribute(name, value);
-            AddDependency(VirtualPath.Create(src, WebFormsFileProvider));
+            AddDependency(VirtualPath.Create(src));
         }
     }
 
@@ -403,7 +403,7 @@ internal abstract class TemplateControlDependencyParser : DependencyParser
                 if (value.Length > 0)
                 {
                     // Add a dependency on the master, whether it has a device filter or not
-                    AddDependency(VirtualPath.Create(value, WebFormsFileProvider));
+                    AddDependency(VirtualPath.Create(value));
                 }
                 break;
 
@@ -428,7 +428,7 @@ internal class PageDependencyParser : TemplateControlDependencyParser
         {
             if (PagesConfig.MasterPageFileInternal != null && PagesConfig.MasterPageFileInternal.Length != 0)
             {
-                AddDependency(VirtualPath.Create(PagesConfig.MasterPageFileInternal, WebFormsFileProvider));
+                AddDependency(VirtualPath.Create(PagesConfig.MasterPageFileInternal));
             }
         }
     }

--- a/src/WebForms/Compilation/TemplateParser.cs
+++ b/src/WebForms/Compilation/TemplateParser.cs
@@ -579,9 +579,9 @@ public abstract class TemplateParser : BaseParser, IAssemblyDependencyParser
         return c;
     }
 
-    public ITemplate ParseTemplate(string content, string virtualPath, bool ignoreFilter)
+    public static ITemplate ParseTemplate(string content, string virtualPath, bool ignoreFilter)
     {
-        return ParseTemplate(content, VirtualPath.Create(virtualPath, WebFormsFileProvider), ignoreFilter);
+        return ParseTemplate(content, VirtualPath.Create(virtualPath), ignoreFilter);
     }
 
     private static ITemplate ParseTemplate(string content, VirtualPath virtualPath, bool ignoreFilter)
@@ -835,7 +835,7 @@ public abstract class TemplateParser : BaseParser, IAssemblyDependencyParser
 
     protected void ParseFile(string physicalPath, string virtualPath)
     {
-        ParseFile(physicalPath, VirtualPath.Create(virtualPath, WebFormsFileProvider));
+        ParseFile(physicalPath, VirtualPath.Create(virtualPath));
     }
 
     internal void ParseFile(string physicalPath, VirtualPath virtualPath)
@@ -871,7 +871,7 @@ public abstract class TemplateParser : BaseParser, IAssemblyDependencyParser
             else
             {
                 // Open a TextReader for the virtualPath we're parsing
-                using (Stream stream = virtualPath.OpenFile())
+                using (Stream stream = virtualPath.OpenFile(WebFormsFileProvider))
                 {
                     reader = Util.ReaderFromStream(stream, CurrentVirtualPath);
                     ParseReader(reader, virtualPath);
@@ -1915,7 +1915,7 @@ private Match RunTextRegex(string text, int textPos) {
             ProcessLanguageAttribute((string)attribs["language"]);
             _currentScript = new ScriptBlockData(1, 1, virtualPath.VirtualPathString);
 
-            _currentScript.Script = Util.StringFromVirtualPath(virtualPath);
+            _currentScript.Script = Util.StringFromVirtualPath(virtualPath, WebFormsFileProvider);
 
             // Add this script to the script builder
             _scriptList.Add(_currentScript);
@@ -2289,7 +2289,7 @@ private Match RunTextRegex(string text, int textPos) {
 
                 try
                 {
-                    ProcessCodeFile(VirtualPath.Create(Util.GetNonEmptyAttribute(name, value), WebFormsFileProvider));
+                    ProcessCodeFile(VirtualPath.Create(Util.GetNonEmptyAttribute(name, value)));
                 }
                 catch (Exception ex)
                 {
@@ -2345,7 +2345,7 @@ private Match RunTextRegex(string text, int textPos) {
         {
             try
             {
-                assembly = ImportSourceFile(VirtualPath.Create(src, WebFormsFileProvider));
+                assembly = ImportSourceFile(VirtualPath.Create(src));
             }
             catch (Exception ex)
             {
@@ -2573,7 +2573,7 @@ private Match RunTextRegex(string text, int textPos) {
         BuildManager.ValidateCodeFileVirtualPath(_codeFileVirtualPath);
 
         // Make sure the file exists
-        Util.CheckVirtualFileExists(_codeFileVirtualPath);
+        Util.CheckVirtualFileExists(_codeFileVirtualPath, WebFormsFileProvider);
 
         _compilerType = compilerType;
 
@@ -2846,7 +2846,7 @@ private Match RunTextRegex(string text, int textPos) {
 
                 try
                 {
-                    newVirtualPath = ResolveVirtualPath(VirtualPath.Create(filename, WebFormsFileProvider));
+                    newVirtualPath = ResolveVirtualPath(VirtualPath.Create(filename));
                 }
                 catch
                 {
@@ -2873,7 +2873,7 @@ private Match RunTextRegex(string text, int textPos) {
         }
         else if (StringUtil.EqualsIgnoreCase(pathType, "virtual"))
         {
-            newVirtualPath = ResolveVirtualPath(VirtualPath.Create(filename, WebFormsFileProvider));
+            newVirtualPath = ResolveVirtualPath(VirtualPath.Create(filename));
 #if PORT_HOSTING
             HttpRuntime.CheckVirtualFilePermission(newVirtualPath.VirtualPathString);
 #endif
@@ -3388,7 +3388,7 @@ private Match RunTextRegex(string text, int textPos) {
                 _pageParserFilter.OnDependencyAdded();
             }
 
-            AddSourceDependency2(VirtualPath.Create(virtualPath, WebFormsFileProvider));
+            AddSourceDependency2(VirtualPath.Create(virtualPath));
         }
     }
 

--- a/src/WebForms/Compilation/TemplateParser.cs
+++ b/src/WebForms/Compilation/TemplateParser.cs
@@ -282,7 +282,7 @@ public abstract class TemplateParser : BaseParser, IAssemblyDependencyParser
             throw new HttpParseException(ex.Message, ex);
         }
 
-        // If it is already a parser exception remember the location corresponding to 
+        // If it is already a parser exception remember the location corresponding to
         // the original error.
         ParserError parseError;
 
@@ -579,9 +579,9 @@ public abstract class TemplateParser : BaseParser, IAssemblyDependencyParser
         return c;
     }
 
-    public static ITemplate ParseTemplate(string content, string virtualPath, bool ignoreFilter)
+    public ITemplate ParseTemplate(string content, string virtualPath, bool ignoreFilter)
     {
-        return ParseTemplate(content, VirtualPath.Create(virtualPath), ignoreFilter);
+        return ParseTemplate(content, VirtualPath.Create(virtualPath, WebFormsFileProvider), ignoreFilter);
     }
 
     private static ITemplate ParseTemplate(string content, VirtualPath virtualPath, bool ignoreFilter)
@@ -835,7 +835,7 @@ public abstract class TemplateParser : BaseParser, IAssemblyDependencyParser
 
     protected void ParseFile(string physicalPath, string virtualPath)
     {
-        ParseFile(physicalPath, VirtualPath.Create(virtualPath));
+        ParseFile(physicalPath, VirtualPath.Create(virtualPath, WebFormsFileProvider));
     }
 
     internal void ParseFile(string physicalPath, VirtualPath virtualPath)
@@ -2289,7 +2289,7 @@ private Match RunTextRegex(string text, int textPos) {
 
                 try
                 {
-                    ProcessCodeFile(VirtualPath.Create(Util.GetNonEmptyAttribute(name, value)));
+                    ProcessCodeFile(VirtualPath.Create(Util.GetNonEmptyAttribute(name, value), WebFormsFileProvider));
                 }
                 catch (Exception ex)
                 {
@@ -2345,7 +2345,7 @@ private Match RunTextRegex(string text, int textPos) {
         {
             try
             {
-                assembly = ImportSourceFile(VirtualPath.Create(src));
+                assembly = ImportSourceFile(VirtualPath.Create(src, WebFormsFileProvider));
             }
             catch (Exception ex)
             {
@@ -2846,7 +2846,7 @@ private Match RunTextRegex(string text, int textPos) {
 
                 try
                 {
-                    newVirtualPath = ResolveVirtualPath(VirtualPath.Create(filename));
+                    newVirtualPath = ResolveVirtualPath(VirtualPath.Create(filename, WebFormsFileProvider));
                 }
                 catch
                 {
@@ -2873,7 +2873,7 @@ private Match RunTextRegex(string text, int textPos) {
         }
         else if (StringUtil.EqualsIgnoreCase(pathType, "virtual"))
         {
-            newVirtualPath = ResolveVirtualPath(VirtualPath.Create(filename));
+            newVirtualPath = ResolveVirtualPath(VirtualPath.Create(filename, WebFormsFileProvider));
 #if PORT_HOSTING
             HttpRuntime.CheckVirtualFilePermission(newVirtualPath.VirtualPathString);
 #endif
@@ -3166,7 +3166,7 @@ private Match RunTextRegex(string text, int textPos) {
             }
 
             // If this is a server ID, remember it
-            // 
+            //
 
             if (StringUtil.EqualsIgnoreCase(realAttributeName, "id"))
             {
@@ -3388,7 +3388,7 @@ private Match RunTextRegex(string text, int textPos) {
                 _pageParserFilter.OnDependencyAdded();
             }
 
-            AddSourceDependency2(VirtualPath.Create(virtualPath));
+            AddSourceDependency2(VirtualPath.Create(virtualPath, WebFormsFileProvider));
         }
     }
 
@@ -3515,7 +3515,7 @@ private Match RunTextRegex(string text, int textPos) {
     internal IImplicitResourceProvider GetImplicitResourceProvider()
     {
 
-        // 
+        //
         if (FInDesigner)
         {
             return null;

--- a/src/WebForms/UI/Util.cs
+++ b/src/WebForms/UI/Util.cs
@@ -965,7 +965,7 @@ internal static class Util
         return type;
     }
 
-    internal static void CheckVirtualFileExists(VirtualPath virtualPath, IFileProvider fileProvider = null)
+    internal static void CheckVirtualFileExists(VirtualPath virtualPath, IFileProvider fileProvider)
     {
         if (!virtualPath.FileExists(fileProvider))
         {
@@ -1014,7 +1014,7 @@ internal static class Util
         }
     }
 
-    internal /*public*/ static String StringFromVirtualPath(VirtualPath virtualPath, IFileProvider fileProvider = null)
+    internal /*public*/ static String StringFromVirtualPath(VirtualPath virtualPath, IFileProvider fileProvider)
     {
 
         using (Stream stream = virtualPath.OpenFile(fileProvider))

--- a/src/WebForms/UI/Util.cs
+++ b/src/WebForms/UI/Util.cs
@@ -8,6 +8,7 @@ using System.Reflection;
 using System.Text;
 using System.Web.UI.WebControls;
 using System.Web.Util;
+using Microsoft.Extensions.FileProviders;
 
 /*
  * Implements various utility functions used by the template code
@@ -491,7 +492,7 @@ internal static class Util
 
         if (!string.IsNullOrEmpty(firstScript))
         {
-            // 
+            //
             return firstScript + secondScript;
         }
         else
@@ -875,7 +876,7 @@ internal static class Util
 
     internal static bool IsLateBoundComClassicType(Type t)
     {
-        // 
+        //
         return (String.Compare(t.FullName, "System.__ComObject", StringComparison.Ordinal) == 0);
     }
 
@@ -964,9 +965,9 @@ internal static class Util
         return type;
     }
 
-    internal static void CheckVirtualFileExists(VirtualPath virtualPath)
+    internal static void CheckVirtualFileExists(VirtualPath virtualPath, IFileProvider fileProvider = null)
     {
-        if (!virtualPath.FileExists())
+        if (!virtualPath.FileExists(fileProvider))
         {
             throw new HttpException(
                 //HttpStatus.NotFound,
@@ -1013,10 +1014,10 @@ internal static class Util
         }
     }
 
-    internal /*public*/ static String StringFromVirtualPath(VirtualPath virtualPath)
+    internal /*public*/ static String StringFromVirtualPath(VirtualPath virtualPath, IFileProvider fileProvider = null)
     {
 
-        using (Stream stream = virtualPath.OpenFile())
+        using (Stream stream = virtualPath.OpenFile(fileProvider))
         {
             // Create a reader on the file, and read the whole thing
             TextReader reader = Util.ReaderFromStream(stream, virtualPath);

--- a/src/WebForms/WebFormsOptions.cs
+++ b/src/WebForms/WebFormsOptions.cs
@@ -1,0 +1,10 @@
+// MIT License.
+
+using Microsoft.Extensions.FileProviders;
+
+namespace System.Web;
+
+public class WebFormsOptions
+{
+    public IFileProvider WebFormsFileProvider { get; set; }
+}

--- a/src/WebForms/WebFormsServiceExtensions.cs
+++ b/src/WebForms/WebFormsServiceExtensions.cs
@@ -1,5 +1,6 @@
 // MIT License.
 
+using System.Web;
 using System.Web.Compilation;
 using System.Web.UI;
 using Microsoft.AspNetCore.SystemWebAdapters;
@@ -14,8 +15,15 @@ namespace Microsoft.AspNetCore.Builder;
 
 public static class WebFormsServiceExtensions
 {
-    public static IWebFormsBuilder AddWebForms(this ISystemWebAdapterBuilder builder)
+    public static IWebFormsBuilder AddWebForms(this ISystemWebAdapterBuilder builder, Action<WebFormsOptions> configure = null)
     {
+        if (configure is not null)
+        {
+            builder.Services.AddOptions<WebFormsOptions>()
+                .Configure(options => VirtualPath.Files = options.WebFormsFileProvider)
+                .Configure(configure);
+        }
+
         builder.AddHttpHandlers();
         builder.AddRouting();
         builder.AddVirtualPathProvider();
@@ -24,11 +32,11 @@ public static class WebFormsServiceExtensions
             .AddDefaultExpressionBuilders();
     }
 
-    public static IWebFormsBuilder AddWebForms(this IServiceCollection builder)
+    public static IWebFormsBuilder AddWebForms(this IServiceCollection builder, Action<WebFormsOptions> configure = null)
         => builder
             .AddSystemWebAdapters()
             .AddWrappedAspNetCoreSession()
-            .AddWebForms();
+            .AddWebForms(configure);
 
     public static IWebFormsBuilder AddDefaultExpressionBuilders(this IWebFormsBuilder builder) => builder
         .AddExpressionBuilder<RouteUrlExpressionBuilder>("RouteUrl");

--- a/src/WebForms/WebFormsServiceExtensions.cs
+++ b/src/WebForms/WebFormsServiceExtensions.cs
@@ -6,6 +6,7 @@ using System.Web.UI;
 using Microsoft.AspNetCore.SystemWebAdapters;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection.Extensions;
+using Microsoft.Extensions.Hosting;
 using WebForms;
 
 [assembly: TagPrefix("System.Web.UI", "asp")]
@@ -17,11 +18,12 @@ public static class WebFormsServiceExtensions
 {
     public static IWebFormsBuilder AddWebForms(this ISystemWebAdapterBuilder builder, Action<WebFormsOptions> configure = null)
     {
+        var optionsBuilder = builder.Services.AddOptions<WebFormsOptions>()
+            .Configure<IHostEnvironment>((options, env) => options.WebFormsFileProvider = env.ContentRootFileProvider);
+
         if (configure is not null)
         {
-            builder.Services.AddOptions<WebFormsOptions>()
-                .Configure(options => VirtualPath.Files = options.WebFormsFileProvider)
-                .Configure(configure);
+            optionsBuilder.Configure(configure);
         }
 
         builder.AddHttpHandlers();


### PR DESCRIPTION
Allow customization of root folder.

Can be used like so:
```cs
.AddWebForms(options => options.WebFormsFileProvider = new PhysicalFileProvider(Path.Combine(builder.Environment.ContentRootPath, "Pages")))
```

Fixes #146