### PR TITLE
Remove hierarchical features from control

### DIFF
--- a/src/WebForms/UI/Control.cs
+++ b/src/WebForms/UI/Control.cs
@@ -368,7 +368,7 @@ public partial class Control : IComponent, IParserAccessor, IDataBindingsAccesso
     Browsable(false),
     DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)
     ]
-    protected internal virtual HttpContext Context => GetHierarchicalFeature<HttpContext>();
+    protected internal virtual HttpContext Context => HttpContext.Current;
 
     /// <devdoc>
     /// Indicates whether a control is being used in the context of a design surface.
@@ -915,7 +915,7 @@ public partial class Control : IComponent, IParserAccessor, IDataBindingsAccesso
     ]
     public Page Page
     {
-        get => page ??= GetHierarchicalFeature<Page>() ?? HttpContext.Current.GetFeature<IHttpHandlerFeature>()?.Current as Page ?? throw new InvalidOperationException();
+        get => page ??= HttpContext.Current.GetRequiredFeature<IHttpHandlerFeature>().Current as Page ?? throw new InvalidOperationException("No page available");
         set => page = value;
     }
 

--- a/src/WebForms/UI/ControlInternals.cs
+++ b/src/WebForms/UI/ControlInternals.cs
@@ -2,7 +2,6 @@
 
 #nullable enable
 
-using Microsoft.AspNetCore.Http.Features;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 
@@ -10,21 +9,5 @@ namespace System.Web.UI;
 
 public partial class Control
 {
-    private IFeatureCollection? _features;
-
-    internal IFeatureCollection Features => _features ??= new FeatureCollection();
-
-    private protected T? GetHierarchicalFeature<T>()
-    {
-        if (_features is not null && _features.Get<T>() is { } t)
-        {
-            return t;
-        }
-
-        return Parent is { } p ? p.GetHierarchicalFeature<T>() : default;
-    }
-
-    internal bool HasViewState => _viewState is not null;
-
     protected internal ILogger Logger => Context.GetRequiredService<ILoggerFactory>().CreateLogger(GetType().FullName ?? GetType().Name);
 }

--- a/src/WebForms/UI/Page.cs
+++ b/src/WebForms/UI/Page.cs
@@ -5832,10 +5832,6 @@ window.onload = WebForm_RestoreScrollPosition;
     // TAP
     private async Task ProcessRequestAsync(HttpContext context)
     {
-        // Set up a few things
-        Features.Set<Page>(this);
-        Features.Set<HttpContext>(context);
-
         // we disallow async operations except during specific portions of the lifecycle
         SynchronizationContext.Current.ProhibitVoidAsyncOperations();
 


### PR DESCRIPTION
This was used during bootstrapping and is no longer needed.

Fixes #188
