### PR TITLE
Use System.Runtime.Caching v8.0.0

### DIFF
--- a/BannedSymbols.txt
+++ b/BannedSymbols.txt
@@ -1,1 +1,0 @@
-T:System.Drawing.ToolboxBitmapAttribute

--- a/CoreWebForms.sln
+++ b/CoreWebForms.sln
@@ -24,7 +24,6 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "samples", "samples", "{97FC
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{ED177FFB-95F7-4040-8984-98A667711A55}"
 	ProjectSection(SolutionItems) = preProject
-		BannedSymbols.txt = BannedSymbols.txt
 		Directory.Build.props = Directory.Build.props
 		Directory.Build.targets = Directory.Build.targets
 		global.json = global.json

--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -1,11 +1,1 @@
-<Project>
-
-  <ItemGroup>
-    <PackageReference Include="Microsoft.CodeAnalysis.BannedApiAnalyzers" Version="3.11.0-beta1.24072.1">
-      <PrivateAssets>all</PrivateAssets>
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-    </PackageReference>
-    <AdditionalFiles Include="$(MSBuildThisFileDirectory)BannedSymbols.txt" />
-  </ItemGroup>
-
-</Project>
+<Project />

--- a/src/Handlers/Handlers.csproj
+++ b/src/Handlers/Handlers.csproj
@@ -11,6 +11,10 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <!-- System.Runtime.Caching had a dependency on System.Drawing.Common which is not supported in .NET 8
+         However, the adapters reference v6.0.0. For now, we'll force WebForms to rely on this, but a later
+         version of the adapters should reference v8.0.0 of the caching library so this is fixed -->
+    <PackageReference Include="System.Runtime.Caching" Version="8.0.0" />
     <PackageReference Include="Microsoft.AspNetCore.SystemWebAdapters.CoreServices" Version="1.3.2" />
     <FrameworkReference Include="Microsoft.AspNetCore.App" />
   </ItemGroup>

--- a/src/WebForms/UI/WebControls/FontInfo.cs
+++ b/src/WebForms/UI/WebControls/FontInfo.cs
@@ -73,7 +73,9 @@ public sealed class FontInfo
     ///    <para>Indicates the name of the font.</para>
     /// </devdoc>
     [
+#if PORT_DRAWING_COMMON
         TypeConverterAttribute(typeof(FontConverter.FontNameConverter)),
+#endif
         WebCategory("Appearance"),
         DefaultValue(""),
         WebSysDescription(SR.FontInfo_Name),


### PR DESCRIPTION
Prior versions (including the one used by the adapters) depends on System.Drawing.Common. This is why we had that showing up available for compilation. This change forces us to use v8.0.0 so we don't accidently rely on it.

Fixes #125