### PR TITLE
Compile in a non-async determined order

### DIFF
--- a/src/Compiler.Dynamic/PageCompilationOptions.cs
+++ b/src/Compiler.Dynamic/PageCompilationOptions.cs
@@ -1,8 +1,5 @@
 // MIT License.
 
-using System.Reflection;
-using System.Web;
-using System.Web.Compilation;
 using System.Web.UI;
 using Microsoft.Extensions.FileProviders;
 
@@ -17,22 +14,17 @@ public class PageCompilationOptions
     public bool IsDebug { get; set; }
     internal IFileProvider WebFormsFileProvider { get; set; } = default!;
 
-    internal Dictionary<string, Func<string, BaseCodeDomTreeGenerator>> Parsers { get; } = new(StringComparer.OrdinalIgnoreCase);
+    internal Dictionary<string, Func<string, BaseTemplateParser>> Parsers { get; } = new(StringComparer.OrdinalIgnoreCase);
 
     internal void AddParser<TParser>(string extension)
         where TParser : BaseTemplateParser, new()
     {
         Parsers.Add(extension, Create);
 
-        BaseCodeDomTreeGenerator Create(string path)
+        BaseTemplateParser Create(string path) => new TParser
         {
-            var parser = new TParser();
-
-            parser.WebFormsFileProvider = WebFormsFileProvider;
-            parser.AddAssemblyDependency(Assembly.GetEntryAssembly(), true);
-            parser.Parse(Array.Empty<string>(), path);
-
-            return parser.GetGenerator();
-        }
+            CurrentVirtualPath = path,
+            WebFormsFileProvider = WebFormsFileProvider
+        };
     }
 }

--- a/src/Handlers/HandlerExtensions.cs
+++ b/src/Handlers/HandlerExtensions.cs
@@ -44,8 +44,7 @@ internal static class HandlerExtensions
         }
         else if (endpoint.Metadata.GetMetadata<IHttpHandlerMetadata>() is { } metadata)
         {
-            // TODO: flow async
-            return metadata.Create(context).AsTask().GetAwaiter().GetResult();
+            return metadata.Create(context);
         }
         else
         {

--- a/src/Handlers/HandlerMetadata.cs
+++ b/src/Handlers/HandlerMetadata.cs
@@ -25,7 +25,7 @@ public static class HandlerMetadata
             _ => SessionStateBehavior.Default,
         };
 
-        public ValueTask<IHttpHandler> Create(HttpContextCore context) => ValueTask.FromResult(handler);
+        public IHttpHandler Create(HttpContextCore context) => handler;
     }
 
     private sealed class TypeHandlerMetadata(string path, Type type) : IHttpHandlerMetadata
@@ -53,11 +53,11 @@ public static class HandlerMetadata
             }
         }
 
-        public ValueTask<IHttpHandler> Create(HttpContextCore context)
+        public IHttpHandler Create(HttpContextCore context)
         {
             if (_handler is { } h)
             {
-                return ValueTask.FromResult(h);
+                return h;
             }
 
             var newHandler = (IHttpHandler)_factory(context.RequestServices, null);
@@ -67,7 +67,7 @@ public static class HandlerMetadata
                 Interlocked.Exchange(ref _handler, newHandler);
             }
 
-            return ValueTask.FromResult(newHandler);
+            return newHandler;
         }
     }
 }

--- a/src/Handlers/IHttpHandlerMetadata.cs
+++ b/src/Handlers/IHttpHandlerMetadata.cs
@@ -11,6 +11,6 @@ public interface IHttpHandlerMetadata
 
     string Route { get; }
 
-    ValueTask<IHttpHandler> Create(HttpContextCore context);
+    IHttpHandler Create(HttpContextCore context);
 }
 

--- a/src/Handlers/SystemWeb/HttpHandlerEndpointConventionBuilder.cs
+++ b/src/Handlers/SystemWeb/HttpHandlerEndpointConventionBuilder.cs
@@ -120,6 +120,6 @@ internal sealed class HttpHandlerEndpointConventionBuilder : EndpointDataSource,
 
         public string Route => route;
 
-        public ValueTask<IHttpHandler> Create(HttpContextCore context) => metadata.Create(context);
+        public IHttpHandler Create(HttpContextCore context) => metadata.Create(context);
     }
 }


### PR DESCRIPTION
This change removes the task-based mechanism to get dependencies for
compilation. This ends up removing a lot of the async that was need
before and allows us to know that dependencies are available when
compilation is occuring.
