### PR TITLE
Add ICompiledTypeAccessor into compilation

### DIFF
--- a/src/Compiler.Dynamic/DynamicSystemWebCompilation.cs
+++ b/src/Compiler.Dynamic/DynamicSystemWebCompilation.cs
@@ -3,6 +3,7 @@
 using System.Reflection;
 using System.Web;
 using System.Web.Routing;
+using System.Web.SessionState;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.SystemWebAdapters;
 using Microsoft.AspNetCore.SystemWebAdapters.HttpHandlers;
@@ -10,6 +11,7 @@ using Microsoft.CodeAnalysis;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using Microsoft.Extensions.Primitives;
+using WebForms.Internal;
 
 using static WebForms.Compiler.Dynamic.DynamicSystemWebCompilation;
 
@@ -62,7 +64,7 @@ internal sealed class DynamicSystemWebCompilation : SystemWebCompilation<Dynamic
 
             _logger.LogWarning("{ErrorCount} error(s) found compiling {Route}", result.Diagnostics.Length, route);
 
-            return new DynamicCompiledPage(this, new(route), [])
+            return new DynamicCompiledPage(new(route), [])
             {
                 Exception = new RoslynCompilationException(route, errors)
             };
@@ -76,7 +78,7 @@ internal sealed class DynamicSystemWebCompilation : SystemWebCompilation<Dynamic
 
         if (assembly.GetType(typeName) is Type type)
         {
-            return new DynamicCompiledPage(this, new(route), embedded.Select(t => t.FilePath).ToArray())
+            return new DynamicCompiledPage(new(route), embedded.Select(t => t.FilePath).ToArray())
             {
                 Type = type,
                 MetadataReference = compilation.ToMetadataReference()
@@ -88,11 +90,13 @@ internal sealed class DynamicSystemWebCompilation : SystemWebCompilation<Dynamic
 
     IEnumerable<IHttpHandlerMetadata> IHttpHandlerCollection.GetHandlerMetadata()
     {
+        var accessor = TypeAccessor;
+
         foreach (var page in GetPages())
         {
             if (page.Type is { } type)
             {
-                yield return HandlerMetadata.Create(page.Path, type);
+                yield return new WrappedMetadata(HandlerMetadata.Create(page.Path, type), accessor);
             }
             else if (page.Exception is { } ex)
             {
@@ -119,17 +123,15 @@ internal sealed class DynamicSystemWebCompilation : SystemWebCompilation<Dynamic
     }
 
     protected override DynamicCompiledPage CreateErrorPage(string path, Exception e)
-        => new(this, new(path), [])
+        => new(new(path), [])
         {
             Exception = e
         };
 
-    internal sealed class DynamicCompiledPage(DynamicSystemWebCompilation compilation, PagePath path, string[] dependencies) : CompiledPage(path, dependencies)
+    internal sealed class DynamicCompiledPage(PagePath path, string[] dependencies) : CompiledPage(path, dependencies)
     {
         public override void Dispose()
         {
-            compilation.RemovePage(Path);
-
             foreach (var d in PageDependencies)
             {
                 d.Dispose();
@@ -159,5 +161,16 @@ internal sealed class DynamicSystemWebCompilation : SystemWebCompilation<Dynamic
                 return Task.CompletedTask;
             }
         }
+    }
+
+    private sealed class WrappedMetadata(IHttpHandlerMetadata metadata, ICompiledTypeAccessor compiledTypes) : IHttpHandlerMetadata, ICompiledTypeAccessor
+    {
+        SessionStateBehavior IHttpHandlerMetadata.Behavior => metadata.Behavior;
+
+        string IHttpHandlerMetadata.Route => metadata.Route;
+
+        IHttpHandler IHttpHandlerMetadata.Create(Microsoft.AspNetCore.Http.HttpContext context) => metadata.Create(context);
+
+        Type? ICompiledTypeAccessor.GetForPath(string virtualPath) => compiledTypes.GetForPath(virtualPath);
     }
 }

--- a/src/Compiler.Dynamic/DynamicSystemWebCompilation.cs
+++ b/src/Compiler.Dynamic/DynamicSystemWebCompilation.cs
@@ -169,6 +169,8 @@ internal sealed class DynamicSystemWebCompilation : SystemWebCompilation<Dynamic
 
         string IHttpHandlerMetadata.Route => metadata.Route;
 
+        Type? ICompiledTypeAccessor.GetForName(string typeName) => compiledTypes.GetForName(typeName);
+
         IHttpHandler IHttpHandlerMetadata.Create(Microsoft.AspNetCore.Http.HttpContext context) => metadata.Create(context);
 
         Type? ICompiledTypeAccessor.GetForPath(string virtualPath) => compiledTypes.GetForPath(virtualPath);

--- a/src/Handlers/SystemWeb/HttpHandlerEndpointConventionBuilder.cs
+++ b/src/Handlers/SystemWeb/HttpHandlerEndpointConventionBuilder.cs
@@ -6,7 +6,6 @@ using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Http.Features;
 using Microsoft.AspNetCore.Routing;
 using Microsoft.AspNetCore.Routing.Patterns;
-using Microsoft.AspNetCore.SystemWebAdapters;
 using Microsoft.AspNetCore.SystemWebAdapters.Features;
 using Microsoft.AspNetCore.SystemWebAdapters.HttpHandlers;
 using Microsoft.Extensions.Primitives;

--- a/src/WebForms/Adapters/ICompiledTypeAccessor.cs
+++ b/src/WebForms/Adapters/ICompiledTypeAccessor.cs
@@ -13,7 +13,11 @@ internal interface ICompiledTypeAccessor
 {
     Type? GetForPath(string virtualPath);
 
-    Type GetRequiredType(string virtualPath) => GetForPath(virtualPath) ?? throw new InvalidOperationException($"Type not available for {virtualPath}");
+    Type? GetForName(string typeName);
+
+    Type GetRequiredForPath(string virtualPath) => GetForPath(virtualPath) ?? throw new InvalidOperationException($"Type not available for {virtualPath}");
+
+    Type GetRequiredForName(string virtualPath) => GetForPath(virtualPath) ?? throw new InvalidOperationException($"Type not available for {virtualPath}");
 }
 
 internal static class CompiledTypeAccessExtensions
@@ -44,6 +48,13 @@ internal static class CompiledTypeAccessExtensions
     private sealed class ContextWrappedAccessor(HttpContextCore context, ICompiledTypeAccessor other) : ICompiledTypeAccessor
     {
         private readonly ILogger _logger = context.RequestServices.GetRequiredService<ILogger<ContextWrappedAccessor>>();
+
+        public Type? GetForName(string typeName)
+        {
+            _logger.LogDebug($"{context.Request.Path} is searching for compiled type {typeName}");
+
+            return other.GetForName(typeName);
+        }
 
         Type? ICompiledTypeAccessor.GetForPath(string virtualPath)
         {

--- a/src/WebForms/Adapters/ICompiledTypeAccessor.cs
+++ b/src/WebForms/Adapters/ICompiledTypeAccessor.cs
@@ -1,0 +1,55 @@
+// MIT License.
+
+#nullable enable
+
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.SystemWebAdapters;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+
+namespace WebForms.Internal;
+
+internal interface ICompiledTypeAccessor
+{
+    Type? GetForPath(string virtualPath);
+
+    Type GetRequiredType(string virtualPath) => GetForPath(virtualPath) ?? throw new InvalidOperationException($"Type not available for {virtualPath}");
+}
+
+internal static class CompiledTypeAccessExtensions
+{
+    public static ICompiledTypeAccessor GetCompiledTypes(this System.Web.HttpContext context) => context.AsAspNetCore().GetRequiredCompiledTypes();
+
+    public static ICompiledTypeAccessor GetRequiredCompiledTypes(this HttpContextCore context) => context.GetCompiledTypes() ?? throw new InvalidOperationException("Compiled types not available");
+
+    public static ICompiledTypeAccessor? GetCompiledTypes(this HttpContextCore context)
+    {
+        if (context.Features.Get<ICompiledTypeAccessor>() is { } feature)
+        {
+            return feature;
+        }
+        var metadata = context.GetEndpoint()?.Metadata;
+        var accessor = metadata?.GetMetadata<ICompiledTypeAccessor>();
+
+        if (accessor is null)
+        {
+            return null;
+        }
+
+        feature = new ContextWrappedAccessor(context, accessor);
+        context.Features.Set<ICompiledTypeAccessor>(feature);
+        return feature;
+    }
+
+    private sealed class ContextWrappedAccessor(HttpContextCore context, ICompiledTypeAccessor other) : ICompiledTypeAccessor
+    {
+        private readonly ILogger _logger = context.RequestServices.GetRequiredService<ILogger<ContextWrappedAccessor>>();
+
+        Type? ICompiledTypeAccessor.GetForPath(string virtualPath)
+        {
+            _logger.LogDebug($"{context.Request.Path} is searching for compiled type {virtualPath}");
+
+            return other.GetForPath(virtualPath);
+        }
+    }
+}


### PR DESCRIPTION
This will allow us to access types for the compilation during compiling as well as during a request.
