### PR TITLE
Consolidate GetReferencedType method

### DIFF
--- a/src/WebForms/Compilation/BaseTemplateParser.cs
+++ b/src/WebForms/Compilation/BaseTemplateParser.cs
@@ -68,9 +68,6 @@ public abstract class BaseTemplateParser : TemplateParser
     {
         var t = GetReferencedType(virtualPath, false /*allowNoCompile*/);
 
-        //This was done differently in original Webform
-        t ??= CompiledTypeAccessor.GetForPath(virtualPath.Path);
-
         // Fail if it's a no compile uc, since it doesn't have a Type we can use
         if (t == null)
         {
@@ -110,7 +107,6 @@ public abstract class BaseTemplateParser : TemplateParser
 
     internal Type GetReferencedType(VirtualPath virtualPath, bool allowNoCompile)
     {
-
         virtualPath = ResolveVirtualPath(virtualPath);
 
         // If we have a page parser filter, make sure the reference is allowed
@@ -190,8 +186,9 @@ public abstract class BaseTemplateParser : TemplateParser
 
         return t;
 #else
-        //.RequestServices.GetRequiredService<ILogger<BaseTemplateParser>>().LogWarning("GetReferenceType {Path}", virtualPath);
-        return null;
+        var t = CompiledTypeAccessor.GetForPath(virtualPath);
+        AddTypeDependency(t);
+        return t;
 #endif
     }
 

--- a/src/WebForms/Compilation/PageCodeDomTreeGenerator.cs
+++ b/src/WebForms/Compilation/PageCodeDomTreeGenerator.cs
@@ -20,6 +20,7 @@ internal class PageCodeDomTreeGenerator : TemplateControlCodeDomTreeGenerator
     private const string dependenciesLocalName = "dependencies";
     private const string outputCacheSettingsLocalName = "outputCacheSettings";
     private const string _previousPagePropertyName = "PreviousPage";
+    private const string _masterPropertyName = "Master";
     private const string _styleSheetThemePropertyName = "StyleSheetTheme";
     private const string outputCacheSettingsFieldName = "__outputCacheSettings";
 
@@ -362,15 +363,10 @@ internal class PageCodeDomTreeGenerator : TemplateControlCodeDomTreeGenerator
             BuildStronglyTypedProperty(_previousPagePropertyName, Parser.PreviousPageType);
         }
 
-        if (Parser.MasterPage is { } master)
+        if (Parser.MasterPageType != null)
         {
-            BuildMasterPageFactory(master);
+            BuildStronglyTypedProperty(_masterPropertyName, Parser.MasterPageType);
         }
-
-        //if (Parser.MasterPage != null)
-        //{
-        //    BuildStronglyTypedProperty(_masterPropertyName, Parser.MasterPage);
-        //}
     }
 
     /*

--- a/src/WebForms/Compilation/TemplateControlCodeDomTreeGenerator.cs
+++ b/src/WebForms/Compilation/TemplateControlCodeDomTreeGenerator.cs
@@ -113,36 +113,6 @@ internal abstract class TemplateControlCodeDomTreeGenerator : BaseTemplateCodeDo
      * Build the strongly typed new property
      */
     // e.g. public new {propertyType} Master { get { return ({propertyType})base.Master; } }
-
-    internal void BuildStronglyTypedProperty(string propertyName, TypeReference type)
-    {
-        CodeMemberProperty prop = new CodeMemberProperty();
-        prop.Attributes &= ~MemberAttributes.AccessMask;
-        prop.Attributes &= ~MemberAttributes.ScopeMask;
-        prop.Attributes |= MemberAttributes.Final | MemberAttributes.New | MemberAttributes.Public;
-        prop.Name = propertyName;
-        prop.Type = new CodeTypeReference(type.Name);
-
-        CodePropertyReferenceExpression propRef = new CodePropertyReferenceExpression(
-            new CodeBaseReferenceExpression(), propertyName);
-
-        prop.GetStatements.Add(new CodeMethodReturnStatement(new CodeCastExpression(type.Name, propRef)));
-        _intermediateClass.Members.Add(prop);
-    }
-
-    internal void BuildMasterPageFactory(TypeReference type)
-    {
-        var prop = new CodeMemberMethod();
-        prop.Attributes &= ~MemberAttributes.AccessMask;
-        prop.Attributes &= ~MemberAttributes.ScopeMask;
-        prop.Attributes |= MemberAttributes.Override | MemberAttributes.Family;
-        prop.Name = "CreateMasterPage";
-        prop.ReturnType = new CodeTypeReference(typeof(MasterPage));
-        prop.Statements.Add(new CodeMethodReturnStatement(new CodeObjectCreateExpression(type.Name)));
-
-        _sourceDataClass.Members.Add(prop);
-    }
-
     internal void BuildStronglyTypedProperty(string propertyName, Type propertyType)
     {
         // VSWhidbey 321818.

--- a/src/WebForms/SR.cs
+++ b/src/WebForms/SR.cs
@@ -319,6 +319,7 @@ internal static class SR
     public const string ConnectionsZone_WarningMessage = "The message that is displayed when an existing connection is no longer valid.";
     public const string Content_allowed_in_top_level_only = "Content controls have to be top-level controls in a content page or a nested master page that references a master page.";
     public const string Content_ContentPlaceHolderID = "The ID of the corresponding ContentPlaceHolder in the master page.";
+    public const string Content_only_allowed_in_content_page = "Content controls are allowed only in content page that references a master page.";
     public const string Content_only_one_contentPlaceHolderID_allowed = "Only one ContentPlaceHolderID attribute is allowed.";
     public const string ContentDirection_LeftToRight = "Left to Right";
     public const string ContentDirection_NotSet = "Not Set";

--- a/src/WebForms/UI/Page.cs
+++ b/src/WebForms/UI/Page.cs
@@ -946,16 +946,14 @@ public partial class Page : TemplateControl, IHttpAsyncHandler
     {
         get
         {
-            if (_master == null && !_preInitWorkComplete && CreateMasterPage() is { } master)
+            if (_master == null && !_preInitWorkComplete)
             {
-                _master = MasterPage.CreateMaster(this, master, _contentTemplateCollection);
+                _master = MasterPage.CreateMaster(this, Context, _masterPageFile, _contentTemplateCollection);
             }
 
             return _master;
         }
     }
-
-    protected virtual MasterPage CreateMasterPage() => null;
 
     private VirtualPath _masterPageFile;
 

--- a/src/WebForms/UI/PageParser.cs
+++ b/src/WebForms/UI/PageParser.cs
@@ -10,7 +10,6 @@ namespace System.Web.UI;
 
 using System;
 using System.Collections;
-using System.Collections.Generic;
 using System.IO;
 using System.Text;
 using System.Web.Compilation;
@@ -26,20 +25,6 @@ using System.Web.Util;
 ///    <para>[To be supplied.]</para>
 /// </devdoc>
 ///
-
-internal class TypeReference
-{
-    public TypeReference(string name, string path)
-    {
-        Name = name;
-        Path = path;
-    }
-
-    public string Name { get; }
-
-    public string Path { get; }
-}
-
 public sealed class PageParser : TemplateControlParser
 {
 #if PORT_TRANSACTIONS
@@ -86,7 +71,8 @@ public sealed class PageParser : TemplateControlParser
     private Type _previousPageType;
     internal Type PreviousPageType { get { return _previousPageType; } }
 
-    internal TypeReference MasterPage { get; private set; }
+    private Type _masterPageType;
+    internal Type MasterPageType { get { return _masterPageType; } }
 
     private string _configMasterPageFile;
 
@@ -328,15 +314,14 @@ public sealed class PageParser : TemplateControlParser
         }
         else if (StringUtil.EqualsIgnoreCase(directiveName, "masterType"))
         {
-
-            if (MasterPage != null)
+            if (_masterPageType != null)
             {
                 ProcessError(SR.GetString(SR.Only_one_directive_allowed, directiveName));
                 return;
             }
 
-            //MasterPage = Util.MakeFullTypeName("ASP", Util.MakeValidTypeNameFromString(directive));
-            //Util.CheckAssignableType(typeof(MasterPage), MasterPage);
+            _masterPageType = GetDirectiveType(directive, directiveName);
+            Util.CheckAssignableType(typeof(MasterPage), _masterPageType);
         }
         else
         {
@@ -624,10 +609,7 @@ public sealed class PageParser : TemplateControlParser
                     // Make sure it has the correct base type
                     if (!typeof(MasterPage).IsAssignableFrom(type))
                     {
-                        var path = VirtualPathProvider.CombineVirtualPathsInternal(this.CurrentVirtualPath, value);
-                        MasterPage = new(Util.MakeFullTypeName("ASP", Util.MakeValidTypeNameFromString(path)), path);
-                        //ProcessError(SR.GetString(SR.Invalid_master_base, value));
-
+                        ProcessError(SR.GetString(SR.Invalid_master_base, value));
                     }
 
                     if (deviceName.Length > 0)


### PR DESCRIPTION
We introduced ICompiledTypeAccessor as a way to get at a compiled type given a virtual path earlier this week. In order to consolidate the GetReferencedType code to utilize this fully, some changes to MasterPage were required. All of these revert the code back to what the original system did; that is, these changes had been put in as we bootstrapped the system and now we can use the original patterns.

Fixes #232