### PR TITLE
Enable cross-language compiling

### DIFF
--- a/src/Compiler.Dynamic/CompiledPage.cs
+++ b/src/Compiler.Dynamic/CompiledPage.cs
@@ -33,7 +33,7 @@ internal class CompiledPage : ICompiledPage
 
     public string AspxFile { get; }
 
-    public MetadataReference? MetadataReference { get; set; }
+    public MetadataReference? MetadataReference { get; init; }
 
     public virtual void Dispose()
     {

--- a/src/Compiler.Dynamic/DynamicSystemWebCompilation.cs
+++ b/src/Compiler.Dynamic/DynamicSystemWebCompilation.cs
@@ -74,12 +74,14 @@ internal sealed class DynamicSystemWebCompilation : SystemWebCompilation<Compile
         var context = new PageAssemblyLoadContext(route, assemblies, _factory.CreateLogger<PageAssemblyLoadContext>());
         var assembly = context.LoadFromStream(peStream, pdbStream);
 
+        peStream.Position = 0;
+
         if (assembly.GetType(typeName) is Type type)
         {
             return new(new(route), embedded.Select(t => t.FilePath).ToArray())
             {
                 Type = type,
-                MetadataReference = compilation.ToMetadataReference()
+                MetadataReference = MetadataReference.CreateFromStream(peStream),
             };
         }
 

--- a/src/Compiler.Dynamic/StaticSystemWebCompilation.cs
+++ b/src/Compiler.Dynamic/StaticSystemWebCompilation.cs
@@ -76,7 +76,7 @@ internal sealed class StaticSystemWebCompilation : SystemWebCompilation<Persiste
             {
                 TypeName = typeName,
                 Assembly = $"WebForms.{typeName}",
-                MetadataReference = compilation.ToMetadataReference(),
+                MetadataReference = MetadataReference.CreateFromFile(peFile),
                 Type = type,
             };
         }

--- a/test/Compiler.Dynamic.Tests/DynamicCompilationTests.cs
+++ b/test/Compiler.Dynamic.Tests/DynamicCompilationTests.cs
@@ -36,6 +36,7 @@ public class DynamicCompilationTests
     [DataRow("test08", "scripts.aspx")]
     [DataRow("test09", "basic_page_with_usercontrol.aspx")]
     [DataRow("test10", "loadusercontrol.aspx")]
+    [DataRow("test11", "cspage.aspx")]
     public async Task CompiledPageRuns(string test, params string[] pages)
     {
         if (test == "test08")

--- a/test/Compiler.Dynamic.Tests/assets/test11/cspage.aspx
+++ b/test/Compiler.Dynamic.Tests/assets/test11/cspage.aspx
@@ -1,0 +1,14 @@
+<%@ page language="C#" autoeventwireup="true" %>
+
+<%@ register src="~/vbcontrol.ascx" tagprefix="mine" tagname="vbcontrol" %>
+
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
+
+<html xmlns="http://www.w3.org/1999/xhtml">
+<body>
+    <form runat="server">
+        <mine:vbcontrol runat="server" />
+    </form>
+
+</body>
+</html>

--- a/test/Compiler.Dynamic.Tests/assets/test11/cspage.aspx._0.html
+++ b/test/Compiler.Dynamic.Tests/assets/test11/cspage.aspx._0.html
@@ -1,0 +1,25 @@
+
+
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
+
+<html xmlns="http://www.w3.org/1999/xhtml">
+<body>
+    <form method="post" action="/cspage.aspx" id="ctl00">
+<div class="aspNetHidden">
+<input type="hidden" name="__VIEWSTATE" id="__VIEWSTATE" value="/wEPDwUKMTA0MzUzMDU4Nw8WAgUTVmFsaWRhdGVSZXF1ZXN0TW9kZQIBZGQ=" />
+</div>
+
+        
+
+<div>
+    Hi from control!
+</div>
+
+    
+<div class="aspNetHidden">
+
+	<input type="hidden" name="__VIEWSTATEGENERATOR" id="__VIEWSTATEGENERATOR" value="4E4961DD" />
+</div></form>
+
+</body>
+</html>

--- a/test/Compiler.Dynamic.Tests/assets/test11/vbcontrol.ascx
+++ b/test/Compiler.Dynamic.Tests/assets/test11/vbcontrol.ascx
@@ -1,0 +1,5 @@
+<%@ Control Language="VB" AutoEventWireup="true" %>
+
+<div>
+    Hi from control!
+</div>

--- a/test/Compiler.Dynamic.Tests/assets/test11/vbcontrol.ascx.cs
+++ b/test/Compiler.Dynamic.Tests/assets/test11/vbcontrol.ascx.cs
@@ -1,0 +1,13 @@
+// MIT License.
+
+using System.Web.UI;
+using System;
+using System.ComponentModel;
+using System.Collections.Generic;
+
+namespace SystemWebUISample;
+
+public partial class TestUserControl : System.Web.UI.UserControl
+{
+    public string HeaderText = "Header Working";
+}


### PR DESCRIPTION
This change enables some pages or controls to be VB and others to be CS.
Before, this would fail because roslyn cannot reference different
languages via compilations; instead, they must be metadata references
from streams/files.
