### PR TITLE
Support slightly better incremental builds

### DIFF
--- a/src/Compiler/Build/WebForms.Compiler.Static.targets
+++ b/src/Compiler/Build/WebForms.Compiler.Static.targets
@@ -4,25 +4,46 @@
     <_HasWebFormsError>false</_HasWebFormsError>
   </PropertyGroup>
 
-  <Target Name="WebFormsCompilation" AfterTargets="CoreBuild" BeforeTargets="GetCopyToOutputDirectoryItems">
+  <Target Name="WebFormsCompilation" AfterTargets="CoreCompile" BeforeTargets="GetCopyToOutputDirectoryItems">
     <PropertyGroup>
       <_WebFormsIsDebug>false</_WebFormsIsDebug>
+      <_WebFormsInputDir>$(MSBuildProjectDirectory)</_WebFormsInputDir>
       <_WebFormsIsDebug Condition=" '$(Configuration.ToUpper())' == 'DEBUG' ">true</_WebFormsIsDebug>
-      <_WebFormsTempDir>$(IntermediateOutputPath)webforms_compile/$([System.Guid]::NewGuid())</_WebFormsTempDir>
+      <_WebFormsTempDir>$(IntermediateOutputPath)webforms_compile/</_WebFormsTempDir>
       <_WebFormsTempDir Condition="!$([System.IO.Path]::IsPathRooted($(_WebFormsTempDir)))">$(ProjectDir)$(_WebFormsTempDir)</_WebFormsTempDir>
       <_WebFormsTempDir>$([MSBuild]::NormalizeDirectory($(_WebFormsTempDir)))</_WebFormsTempDir>
       <_WebFormsPagesFileName>webforms.pages.json</_WebFormsPagesFileName>
       <_WebFormsPagesFile>$(_WebFormsTempDir)/$(_WebFormsPagesFileName)</_WebFormsPagesFile>
     </PropertyGroup>
+
+    <ItemGroup>
+      <_WebFormsCompilerInput Include="@(WebFormsFiles)" />
+      <_WebFormsCompilerInput Include="@(WebFormsDesignerFiles)" />
+      <_WebFormsCompilerInput Include="@(WebFormsCodeBehindFiles)" />
+      <_WebFormsCompilerInput Include="@(WebFormsCodeBehindFiles)" />
+      <_WebFormsCompilerInput Include="@(IntermediateAssembly)" />
+    </ItemGroup>
+
+    <ItemGroup>
+      <_WebFormsCompilerOutput Include="$(_WebFormsTempDir)ASP.$([System.String]::Copy('%(WebFormsFiles.RecursiveDir)%(FileName)%(Extension)').Replace('\\', '_').Replace('/', '_')).dll" />
+    </ItemGroup>
+
+    <ItemGroup>
+      <UpToDateCheckInput Include="@(_WebFormsCompilerInput)" />
+      <UpToDateCheckOutput Include="@(_WebFormsCompilerOutput)" />
+    </ItemGroup>
+
   </Target>
 
-  <Target Name="InvokeAspNetCompiler" AfterTargets="WebFormsCompilation" Condition="Exists($(AspNetCompilePath))">
+  <Target Name="InvokeAspNetCompiler" Inputs="@(_WebFormsCompilerInput)" Outputs="@(_WebFormsCompilerOutput)" AfterTargets="WebFormsCompilation" Condition="Exists($(AspNetCompilePath))">
     <PropertyGroup>
       <__AspNetCompileRspFilePath>$(_WebFormsTempDir)input.rsp</__AspNetCompileRspFilePath>
     </PropertyGroup>
 
+    <RemoveDir Directories="$(_WebFormsTempDir)" />
+
     <ItemGroup>
-      <__AspNetCompileRsp Include="-p &quot;$(MSBuildProjectDirectory)&quot;" />
+      <__AspNetCompileRsp Include="-p &quot;$(_WebFormsInputDir)&quot;" />
       <__AspNetCompileRsp Condition="$(_WebFormsIsDebug)" Include="-d" />
       <__AspNetCompileRsp Include="&quot;$(_WebFormsTempDir)&quot;" />
       <__AspNetCompileRsp Include="-r &quot;%(ReferencePath.Identity)&quot;" />
@@ -40,10 +61,13 @@
     </PropertyGroup>
   </Target>
 
-  <Target Name="CollectWebFormsOutput" AfterTargets="InvokeAspNetCompiler" Condition="!$(_HasWebFormsError)" BeforeTargets="GetCopyToOutputDirectoryItems;GetCopyToPublishDirectoryItems">
+  <Target Name="CollectWebFormsOutput" AfterTargets="InvokeAspNetCompiler" Condition="!$(_HasWebFormsError)" BeforeTargets="_CopyFilesMarkedCopyLocal;GetCopyToOutputDirectoryItems;GetCopyToPublishDirectoryItems">
     <ItemGroup>
       <AspxOutputFiles Include="$(_WebFormsTempDir)/*.pdb" />
       <AspxOutputFiles Include="$(_WebFormsTempDir)/*.dll" />
+
+      <FileWrites Include="@(AspxOutputFiles)" />
+      <FileWrites Include="$(_WebFormsPagesFile)" />
 
       <ContentWithTargetPath Include="$(_WebFormsPagesFile)"
                              TargetPath="$(TargetName).webforms.json"


### PR DESCRIPTION
This change reuses the same obj folder instead of a new one for each compilation of the static compiler. Items are also tracked as inputs/outputs so the project will only be built if needed.
