### PR TITLE
4. Introduce new compilation build providers and resource handlers

### DIFF
--- a/src/WebForms/Compilation/BaseCodeDomTreeGenerator.cs
+++ b/src/WebForms/Compilation/BaseCodeDomTreeGenerator.cs
@@ -25,6 +25,8 @@ BaseCodeDomTreeGenerator
     ApplicationFileCodeDomTreeGenerator
 ***********************************************/
 
+using System.Web.Configuration;
+
 namespace System.Web.Compilation;
 internal abstract class BaseCodeDomTreeGenerator
 {
@@ -243,7 +245,7 @@ protected void AppendDebugComment(CodeStatementCollection statements) {
             {
 
                 _sourceDataClass = new CodeTypeDeclaration(generatedClassName);
-                // VSWhidbey 411701. Always use global type reference for the baseType 
+                // VSWhidbey 411701. Always use global type reference for the baseType
                 // when codefile is present.
                 _sourceDataClass.BaseTypes.Add(CodeDomUtility.BuildGlobalCodeTypeReference(
                     UI.Util.MakeFullTypeName(Parser.BaseTypeNamespace, Parser.BaseTypeName)));
@@ -774,7 +776,7 @@ private void BuildSessionObjectProperties() {
             {
                 // If it's a <%= ... %> block, we always generate '__o = expr' is
                 // designer mode, so the column is fixed
-                // 
+                //
                 generatedColumn = BaseTemplateCodeDomTreeGenerator.tempObjectVariable.Length +
                     GetGeneratedColumnOffset(_codeDomProvider);
             }
@@ -919,7 +921,7 @@ private void BuildSessionObjectProperties() {
 
             // Due to config system limitations, we can end up with virtualPath
             // actually being a physical path.  If that's the case, just use it as is.
-            // 
+            //
 
             pragmaFile = virtualPath;
         }

--- a/src/WebForms/Compilation/BaseResourcesBuildProvider.cs
+++ b/src/WebForms/Compilation/BaseResourcesBuildProvider.cs
@@ -1,0 +1,204 @@
+//------------------------------------------------------------------------------
+// <copyright file="BaseResourcesBuildProvider.cs" company="Microsoft">
+//     Copyright (c) Microsoft Corporation.  All rights reserved.
+// </copyright>
+//------------------------------------------------------------------------------
+
+namespace System.Web.Compilation {
+
+using System;
+using System.Resources;
+// using System.Resources.Tools;
+using System.Reflection;
+using System.Globalization;
+using System.Collections;
+using System.IO;
+using System.Xml;
+using System.Xml.Schema;
+using System.CodeDom;
+using System.CodeDom.Compiler;
+using System.Web.Configuration;
+using System.Web.Hosting;
+using System.Web.Compilation;
+using System.Web.UI;
+using System.Web.Util;
+using Util=System.Web.UI.Util;
+
+/// Base class for BuildProviders that generate resources
+[BuildProviderAppliesTo(BuildProviderAppliesTo.Resources)]
+internal abstract class BaseResourcesBuildProvider : BuildProvider {
+
+    internal const string DefaultResourcesNamespace = "Resources";
+
+    // The generated namespace and type name
+    private string _ns;
+    private string _typeName;
+
+    private string _cultureName;
+    private bool _dontGenerateStronglyTypedClass;
+
+    internal void DontGenerateStronglyTypedClass() {
+        _dontGenerateStronglyTypedClass = true;
+    }
+
+    public override void GenerateCode(AssemblyBuilder assemblyBuilder) {
+
+        _cultureName = GetCultureName();
+
+        if (!_dontGenerateStronglyTypedClass) {
+            // Get the namespace and type name that we will use
+            _ns = Util.GetNamespaceAndTypeNameFromVirtualPath(VirtualPathObject,
+                (_cultureName == null) ? 1 : 2 /*chunksToIgnore*/, out _typeName);
+
+            // Always prepend the namespace with Resources.
+            if (_ns.Length == 0)
+                _ns = DefaultResourcesNamespace;
+            else
+                _ns = DefaultResourcesNamespace + "." + _ns;
+        }
+
+        // Get an input stream for our virtual path, and get a resource reader from it
+        using (Stream inputStream = OpenStream()) {
+            IResourceReader reader = GetResourceReader(inputStream);
+
+            try {
+                GenerateResourceFile(assemblyBuilder, reader);
+            }
+            catch (ArgumentException e) {
+                // If the inner exception is Xml, throw that instead, as it contains more
+                // useful info
+                if (e.InnerException != null &&
+                    (e.InnerException is XmlException || e.InnerException is XmlSchemaException)) {
+                    throw e.InnerException;
+                }
+
+                // Otherwise, so just rethrow
+                throw;
+            }
+
+            // Skip the code part for satellite assemblies, or if dontGenerate is set
+            if (_cultureName == null && !_dontGenerateStronglyTypedClass)
+                GenerateStronglyTypedClass(assemblyBuilder, reader);
+        }
+    }
+
+    protected abstract IResourceReader GetResourceReader(Stream inputStream);
+
+    private void GenerateResourceFile(AssemblyBuilder assemblyBuilder, IResourceReader reader) {
+
+        // Get the name of the generated .resource file
+        string resourceFileName;
+        if (_ns == null) {
+            // In the case where we don't generate code, just name the resource file
+            // after the virtual file
+            resourceFileName = UrlPath.GetFileNameWithoutExtension(VirtualPath) + ".resources";
+        }
+        else if (_cultureName == null) {
+            // Name the resource file after the generated class, since that's what the
+            // generated class expects
+            resourceFileName = _ns + "." + _typeName + ".resources";
+        }
+        else {
+            // If it's a non-default resource, include the culture in the name
+            resourceFileName = _ns + "." + _typeName + "." + _cultureName + ".resources";
+        }
+
+        // Make it lower case, since GetManifestResourceStream (which we use later on) is
+        // case sensitive
+        resourceFileName = resourceFileName.ToLower(CultureInfo.InvariantCulture);
+
+        Stream outputStream = null;
+
+        try {
+            try {
+                try {
+                }
+                finally {
+                    // Put the assignment in a finally block to avoid a ThreadAbortException from
+                    // causing the created stream to not get assigned and become leaked (Dev10 bug 844463)
+                    outputStream = assemblyBuilder.CreateEmbeddedResource(this, resourceFileName);
+                }
+            }
+            catch (ArgumentException) {
+                // This throws an ArgumentException if the resource file name was already added.
+                // Catch the situation, and give a better error message (VSWhidbey 87110)
+
+                throw new HttpException(SR.GetString(SR.Duplicate_Resource_File, VirtualPath));
+            }
+
+            // Create an output stream from the .resource file
+            using (outputStream) {
+                using (ResourceWriter writer = new ResourceWriter(outputStream)) {
+                    // Enable resource writer to be target-aware
+                    writer.TypeNameConverter = System.Web.UI.TargetFrameworkUtil.TypeNameConverter;
+
+                    // Copy the resources
+                    foreach (DictionaryEntry de in reader) {
+                        writer.AddResource((string)de.Key, de.Value);
+                    }
+                }
+            }
+        }
+        finally {
+            // Always close the stream to avoid a ThreadAbortException from causing the stream
+            // to be leaked (Dev10 bug 844463)
+            if (outputStream != null) {
+                outputStream.Close();
+            }
+        }
+    }
+
+    private void GenerateStronglyTypedClass(AssemblyBuilder assemblyBuilder, IResourceReader reader) {
+
+        // TODO: Migration
+        throw new NotImplementedException();
+        // Copy the resources into an IDictionary
+        // IDictionary resourceList;
+        // using (reader) {
+        //     resourceList = GetResourceList(reader);
+        // }
+
+        // Generate a strongly typed class from the resources
+        // CodeDomProvider provider = assemblyBuilder.CodeDomProvider;
+        // string[] unmatchable;
+        // CodeCompileUnit ccu = StronglyTypedResourceBuilder.Create(
+        //     resourceList, _typeName, _ns,
+        //     provider, false /*internalClass*/, out unmatchable);
+
+        // Ignore the unmatchable items.  We just won't generate code for them,
+        // but they'll still be usable via the ResourceManager (VSWhidbey 248226)
+
+// We decided to cut support for My.Resources (VSWhidbey 358088)
+#if OLD
+        // generate a My.Resources.* override (VSWhidbey 251554)
+        CodeNamespace ns = new CodeNamespace();
+        ns.Name = "My." + _ns;
+
+        CodeTypeDeclaration type = new CodeTypeDeclaration();
+        type.Name = _typeName;
+        CodeTypeReference baseType = new CodeTypeReference(_ns + "." + _typeName);
+
+        // Need to use a global reference to avoid a conflict, since the classes have the same name
+        baseType.Options = CodeTypeReferenceOptions.GlobalReference;
+        type.BaseTypes.Add(baseType);
+
+        ns.Types.Add(type);
+        ccu.Namespaces.Add(ns);
+#endif
+
+        // Add the code compile unit to the compilation
+        // assemblyBuilder.AddCodeCompileUnit(this, ccu);
+    }
+
+    private IDictionary GetResourceList(IResourceReader reader) {
+
+        // Read the resources into a dictionary.
+        IDictionary resourceList = new Hashtable(StringComparer.OrdinalIgnoreCase);
+        foreach(DictionaryEntry de in reader)
+            resourceList.Add(de.Key, de.Value);
+
+        return resourceList;
+    }
+}
+
+}

--- a/src/WebForms/Compilation/BaseTemplateBuildProvider.cs
+++ b/src/WebForms/Compilation/BaseTemplateBuildProvider.cs
@@ -1,0 +1,198 @@
+﻿//------------------------------------------------------------------------------
+// <copyright file="BaseTemplateBuildProvider.cs" company="Microsoft">
+//     Copyright (c) Microsoft Corporation.  All rights reserved.
+// </copyright>
+//------------------------------------------------------------------------------
+
+
+
+namespace System.Web.Compilation {
+
+using System;
+using System.IO;
+using System.Collections;
+using System.Collections.Specialized;
+using System.Reflection;
+using System.CodeDom;
+using System.CodeDom.Compiler;
+using System.Web.Util;
+using System.Web.UI;
+
+internal abstract class BaseTemplateBuildProvider: InternalBuildProvider
+{
+
+    private TemplateParser _parser;
+
+    internal TemplateParser Parser
+    {
+        get
+        {
+            if(_parser == null)
+                _parser = CreateParser();
+            return _parser;
+        }
+    }
+
+    internal override IAssemblyDependencyParser AssemblyDependencyParser {
+        get { return _parser; }
+    }
+
+    private string _instantiatableFullTypeName;
+    private string _intermediateFullTypeName;
+
+    protected abstract TemplateParser CreateParser();
+
+    internal abstract BaseCodeDomTreeGenerator CreateCodeDomTreeGenerator(TemplateParser parser);
+
+
+    public override CompilerType CodeCompilerType {
+        get {
+            Debug.Assert(_parser == null);
+
+            _parser = CreateParser();
+
+            if (IgnoreParseErrors)
+                _parser.IgnoreParseErrors = true;
+
+            if (IgnoreControlProperties)
+                _parser.IgnoreControlProperties = true;
+
+            if (!ThrowOnFirstParseError)
+                _parser.ThrowOnFirstParseError = false;
+
+            _parser.Parse(ReferencedAssemblies, VirtualPathObject);
+
+            // If the page is non-compiled, don't ask for a language
+            if (!Parser.RequiresCompilation)
+                return null;
+
+            return _parser.CompilerType;
+        }
+    }
+
+    internal override ICollection GetCompileWithDependencies() {
+
+        // If there is a code besides file, return it
+        // TODO: Migration
+        // if (_parser.CodeFileVirtualPath == null)
+        if (_parser?.CodeFileVirtualPath == null)
+            return null;
+
+        // no-compile pages should not have any compile with dependencies
+        Debug.Assert(Parser.RequiresCompilation);
+
+        return new SingleObjectCollection(_parser.CodeFileVirtualPath);
+    }
+
+
+// Todo : Migration
+    //public override void GenerateCode(AssemblyBuilder assemblyBuilder) {
+        // Todo : Migration
+        // // Don't generate any code for no-compile pages
+        // if (!Parser.RequiresCompilation)
+        //     return;
+        //
+        // BaseCodeDomTreeGenerator treeGenerator = CreateCodeDomTreeGenerator(_parser);
+        //
+        // CodeCompileUnit ccu = treeGenerator.GetCodeDomTree(assemblyBuilder.CodeDomProvider,
+        //     assemblyBuilder.StringResourceBuilder, VirtualPathObject);
+        //
+        // if (ccu != null) {
+        //     // Add all the assemblies
+        //     if (_parser.AssemblyDependencies != null) {
+        //         foreach (Assembly assembly in _parser.AssemblyDependencies) {
+        //             assemblyBuilder.AddAssemblyReference(assembly, ccu);
+        //         }
+        //     }
+        //
+        //     assemblyBuilder.AddCodeCompileUnit(this, ccu);
+        // }
+        //
+        // // Get the name of the generated type that can be instantiated.  It may be null
+        // // in updatable compilation scenarios.
+        // _instantiatableFullTypeName = treeGenerator.GetInstantiatableFullTypeName();
+        //
+        // // tell the assembly builder to generate a fast factory for this type
+        // if (_instantiatableFullTypeName != null)
+        //     assemblyBuilder.GenerateTypeFactory(_instantiatableFullTypeName, ccu);
+        //
+        // _intermediateFullTypeName = treeGenerator.GetIntermediateFullTypeName();
+    //}
+
+    public override Type GetGeneratedType(CompilerResults results) {
+        return GetGeneratedType(results, useDelayLoadTypeIfEnabled: false);
+    }
+
+    internal Type GetGeneratedType(CompilerResults results, bool useDelayLoadTypeIfEnabled) {
+
+        // No Type is generated for no-compile pages
+        if (!Parser.RequiresCompilation)
+            return null;
+
+        // Figure out the Type that needs to be persisted
+        string typeName;
+
+        if (_instantiatableFullTypeName == null) {
+
+            if (Parser.CodeFileVirtualPath != null) {
+                // Updatable precomp of a code separation page: use the intermediate type
+                typeName = _intermediateFullTypeName;
+            }
+            else {
+                // Updatable precomp of a single page: use the base type, since nothing got compiled
+                return Parser.BaseType;
+            }
+        }
+        else {
+            typeName = _instantiatableFullTypeName;
+        }
+
+        Debug.Assert(typeName != null);
+
+        Type generatedType;
+        // Todo : Migration
+        // if (useDelayLoadTypeIfEnabled && DelayLoadType.Enabled) {
+        //     string assemblyFilename = Path.GetFileName(results.PathToAssembly);
+        //     string assemblyName = Util.GetAssemblyNameFromFileName(assemblyFilename);
+        //     generatedType = new DelayLoadType(assemblyName, typeName);
+        // }
+        // else {
+            generatedType = results.CompiledAssembly.GetType(typeName);
+        //}
+
+        // It should always extend the required base type
+        // Note: removing this assert as advanced ControlBuilder scenarios allow changing the base type
+        //Debug.Assert(Parser.BaseType.IsAssignableFrom(generatedType));
+
+        return generatedType;
+    }
+
+    internal override BuildResultCompiledType CreateBuildResult(Type t) {
+        return new BuildResultCompiledTemplateType(t);
+    }
+
+    public override ICollection VirtualPathDependencies {
+        get {
+            return _parser.SourceDependencies;
+        }
+    }
+
+    internal override ICollection GetGeneratedTypeNames() {
+        if (_parser.GeneratedClassName == null && _parser.BaseTypeName == null) {
+            return null;
+        }
+
+        ArrayList collection = new ArrayList();
+        if (_parser.GeneratedClassName != null) {
+            collection.Add(_parser.GeneratedClassName);
+        }
+
+        if (_parser.BaseTypeName != null) {
+            collection.Add(Util.MakeFullTypeName(_parser.BaseTypeNamespace, _parser.BaseTypeName));
+        }
+
+        return collection;
+    }
+}
+
+}

--- a/src/WebForms/Compilation/BatchParser.cs
+++ b/src/WebForms/Compilation/BatchParser.cs
@@ -4,6 +4,7 @@ using System.Collections;
 using System.Collections.Specialized;
 using System.Globalization;
 using System.Text.RegularExpressions;
+using System.Web.Configuration;
 using System.Web.Util;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Options;
@@ -20,6 +21,9 @@ internal static class MTConfigUtil
     internal static PagesSection GetPagesConfig() => HttpRuntime.WebObjectActivator.GetRequiredService<IOptions<PagesSection>>().Value;
 
     internal static PagesSection GetPagesConfig(VirtualPath virtualPath) => GetPagesConfig();
+
+    // Counterpart for RuntimeConfig.GetAppConfig().Profile;
+    internal static ProfileSection GetProfileAppConfig() => HttpRuntime.WebObjectActivator.GetRequiredService<IOptions<ProfileSection>>().Value;
 }
 
 internal abstract class DependencyParser : BaseParser
@@ -53,7 +57,7 @@ internal abstract class DependencyParser : BaseParser
             {
                 return _baseTemplateParser;
             }
-            
+
             _baseTemplateParser = InitializeBaseTemplateParser();
             return _baseTemplateParser;
         }
@@ -476,7 +480,7 @@ internal class PageDependencyParser : TemplateControlDependencyParser
     }
 
     protected override BaseTemplateParser CreateTemplateParser() => new PageParser();
-   
+
     internal override void ProcessDirective(string directiveName, IDictionary directive)
     {
         base.ProcessDirective(directiveName, directive);

--- a/src/WebForms/Compilation/BuildDependencySet.cs
+++ b/src/WebForms/Compilation/BuildDependencySet.cs
@@ -1,0 +1,35 @@
+//------------------------------------------------------------------------------
+// <copyright file="BuildDependencySet.cs" company="Microsoft">
+//     Copyright (c) Microsoft Corporation.  All rights reserved.
+// </copyright>
+//------------------------------------------------------------------------------
+
+/************************************************************************************************************/
+
+
+
+namespace System.Web.Compilation {
+
+    using System.Collections;
+    using System.Security.Permissions;
+
+
+    /// <devdoc>
+    ///    <para>
+    ///       Dependency set returned by BuildManager.GetCachedBuildDependencySet
+    ///    </para>
+    /// </devdoc>
+    public sealed class BuildDependencySet {
+
+        private BuildResult _result;
+
+        internal BuildDependencySet(BuildResult result) {
+            _result = result;
+        }
+
+
+        public string HashCode { get { return _result.VirtualPathDependenciesHash; } }
+
+        public IEnumerable VirtualPaths { get { return _result.VirtualPathDependencies; } }
+    }
+}

--- a/src/WebForms/Compilation/BuildProviderAppliesTo.cs
+++ b/src/WebForms/Compilation/BuildProviderAppliesTo.cs
@@ -1,0 +1,16 @@
+//------------------------------------------------------------------------------
+// <copyright file="BuildProviderAppliesTo.cs" company="Microsoft">
+//     Copyright (c) Microsoft Corporation.  All rights reserved.
+// </copyright>
+//------------------------------------------------------------------------------
+
+namespace System.Web.Compilation {
+
+    [Flags]
+    public enum BuildProviderAppliesTo {
+        Web             = 0x1,
+        Code            = 0x2,
+        Resources       = 0x4,
+        All             = 0x7,
+    }
+}

--- a/src/WebForms/Compilation/BuildProviderAppliesToAttribute.cs
+++ b/src/WebForms/Compilation/BuildProviderAppliesToAttribute.cs
@@ -1,0 +1,27 @@
+//------------------------------------------------------------------------------
+// <copyright file="BuildProviderAppliesToAttribute.cs" company="Microsoft">
+//     Copyright (c) Microsoft Corporation.  All rights reserved.
+// </copyright>
+//------------------------------------------------------------------------------
+
+namespace System.Web.Compilation {
+
+    using System.Security.Permissions;
+    using System.Web.Configuration;
+
+    [AttributeUsage(AttributeTargets.Class, AllowMultiple = false)]
+    public sealed class BuildProviderAppliesToAttribute : Attribute {
+
+        private BuildProviderAppliesTo _appliesTo;
+
+        public BuildProviderAppliesToAttribute(BuildProviderAppliesTo appliesTo) {
+            _appliesTo = appliesTo;
+        }
+
+        public BuildProviderAppliesTo AppliesTo {
+            get {
+                return _appliesTo;
+            }
+        }
+    }
+}

--- a/src/WebForms/Compilation/BuildResultCache.cs
+++ b/src/WebForms/Compilation/BuildResultCache.cs
@@ -1,0 +1,1172 @@
+﻿//------------------------------------------------------------------------------
+// <copyright file="BuildResultCache.cs" company="Microsoft">
+//     Copyright (c) Microsoft Corporation.  All rights reserved.
+// </copyright>
+//------------------------------------------------------------------------------
+
+
+
+/*********************************
+
+BuildResultCache
+    MemoryBuildResultCache
+    DiskBuildResultCache
+        StandardDiskBuildResultCache
+        PrecompBaseDiskBuildResultCache
+            PrecompilerDiskBuildResultCache
+            PrecompiledSiteDiskBuildResultCache
+
+**********************************/
+
+namespace System.Web.Compilation;
+
+using System;
+using System.IO;
+using System.Collections;
+using System.Diagnostics.CodeAnalysis;
+using System.Globalization;
+using System.Text;
+using System.Threading;
+using System.Reflection;
+using System.Security.Permissions;
+using System.Web.Hosting;
+using System.Web.Util;
+using System.Web.Caching;
+using System.Web.UI;
+
+internal abstract class BuildResultCache
+{
+    internal BuildResult GetBuildResult(string cacheKey)
+    {
+        return GetBuildResult(cacheKey, null /*virtualPath*/, 0 /*hashCode*/);
+    }
+
+    internal abstract BuildResult GetBuildResult(string cacheKey, VirtualPath virtualPath, long hashCode,
+        bool ensureIsUpToDate = true);
+
+    internal void CacheBuildResult(string cacheKey, BuildResult result, DateTime utcStart)
+    {
+        CacheBuildResult(cacheKey, result, 0 /*hashCode*/, utcStart);
+    }
+
+    internal abstract void CacheBuildResult(string cacheKey, BuildResult result,
+        long hashCode, DateTime utcStart);
+
+    internal static string GetAssemblyCacheKey(string assemblyPath)
+    {
+        string assemblyName = Util.GetAssemblyNameFromFileName(Path.GetFileName(assemblyPath));
+        return GetAssemblyCacheKeyFromName(assemblyName);
+    }
+
+    internal static string GetAssemblyCacheKey(Assembly assembly)
+    {
+        Debug.Assert(!assembly.GlobalAssemblyCache);
+        return GetAssemblyCacheKeyFromName(assembly.GetName().Name);
+    }
+
+    internal static string GetAssemblyCacheKeyFromName(string assemblyName)
+    {
+        Debug.Assert(StringUtil.StringStartsWith(assemblyName, BuildManager.AssemblyNamePrefix));
+        // TODO: Migration
+        // return CacheInternal.PrefixAssemblyPath + assemblyName.ToLowerInvariant();
+        return assemblyName.ToLowerInvariant();
+    }
+
+}
+
+internal class MemoryBuildResultCache : BuildResultCache
+{
+
+    private CacheItemRemovedCallback _onRemoveCallback;
+
+    // The keys are simple assembly names
+    // The values are ArrayLists containing the simple names of assemblies that depend on it
+    private Hashtable _dependentAssemblies = new Hashtable();
+
+    internal MemoryBuildResultCache()
+    {
+
+        // Register an AssemblyLoad event
+        AppDomain.CurrentDomain.AssemblyLoad += new AssemblyLoadEventHandler(OnAssemblyLoad);
+    }
+
+    private void OnAssemblyLoad(object sender, AssemblyLoadEventArgs args)
+    {
+        Assembly a = args.LoadedAssembly;
+
+        // Ignore GAC assemblies
+        if (a.GlobalAssemblyCache)
+            return;
+
+        // Ignore assemblies that don't start with our prefix
+        string name = a.GetName().Name;
+        if (!StringUtil.StringStartsWith(name, BuildManager.AssemblyNamePrefix))
+            return;
+
+        // Go through all the assemblies it references
+        foreach (AssemblyName assemblyName in a.GetReferencedAssemblies())
+        {
+
+            // Ignore references that don't start with our prefix
+            if (!StringUtil.StringStartsWith(assemblyName.Name, BuildManager.AssemblyNamePrefix))
+                continue;
+
+            lock (_dependentAssemblies)
+            {
+                // Check whether we already have an ArrayList for this reference
+                ArrayList dependentList = _dependentAssemblies[assemblyName.Name] as ArrayList;
+                if (dependentList == null)
+                {
+                    // If not, create one and add it to the hashtable
+                    dependentList = new ArrayList();
+                    _dependentAssemblies[assemblyName.Name] = dependentList;
+                }
+
+                // Add the assembly that just got loaded as a dependent
+                Debug.Assert(!dependentList.Contains(name));
+                dependentList.Add(name);
+            }
+        }
+    }
+
+    internal override BuildResult GetBuildResult(string cacheKey, VirtualPath virtualPath, long hashCode,
+        bool ensureIsUpToDate)
+    {
+        Debug.WriteLine("BuildResultCache", "Looking for '" + cacheKey + "' in the memory cache");
+
+        string key = GetMemoryCacheKey(cacheKey);
+        BuildResult result = (BuildResult)HttpRuntime.Cache.Get(key);
+
+        // Not found in the cache
+        if (result == null)
+        {
+            Debug.WriteLine("BuildResultCache", "'" + cacheKey + "' was not found in the memory cache");
+            return null;
+        }
+
+        // We found it in the cache, but is it up to date.  First, if it uses a CacheDependency,
+        // it must be up to date (this is the default case when using MapPathBasedVirtualPathProvider).
+        // If not, then we need to explicitely check that it's up to date (more expensive)
+        if (!result.UsesCacheDependency && !result.IsUpToDate(virtualPath, ensureIsUpToDate))
+        {
+
+            Debug.WriteLine("BuildResultCache", "'" + cacheKey + "' was found but is out of date");
+
+            // Remove it from the cache
+            HttpRuntime.Cache.Remove(key);
+
+            // Debug.Assert(HttpRuntime.Cache.Get(key) == null);
+
+            return null;
+        }
+
+        Debug.WriteLine("BuildResultCache", "'" + cacheKey + "' was found in the memory cache");
+
+        // It's up to date: return it
+        return result;
+    }
+
+    internal override void CacheBuildResult(string cacheKey, BuildResult result,
+        long hashCode, DateTime utcStart)
+    {
+
+        ICollection virtualDependencies = result.VirtualPathDependencies;
+
+        Debug.WriteLine("BuildResultCache", "Adding cache " + cacheKey + " in the memory cache");
+
+        CacheDependency cacheDependency = null;
+
+        if (virtualDependencies != null)
+        {
+            // TODO: Migration
+            // cacheDependency = result.VirtualPath.GetCacheDependency(virtualDependencies, utcStart);
+
+            // If we got a cache dependency, remember that in the BuildResult
+            if (cacheDependency != null)
+                result.UsesCacheDependency = true;
+        }
+
+        // If it should not be cached to memory, leave it alone
+        if (!result.CacheToMemory)
+        {
+            return;
+        }
+
+        if (BuildResultCompiledType.UsesDelayLoadType(result))
+        {
+            // If the result is delaying loading of assembly, then don't cache
+            // to avoid having to load the assembly.
+            return;
+        }
+
+        BuildResultCompiledAssemblyBase compiledResult = result as BuildResultCompiledAssemblyBase;
+        if (compiledResult != null && compiledResult.ResultAssembly != null && !compiledResult.UsesExistingAssembly)
+        {
+
+            // Insert a new cache entry using the assembly path as the key
+            string assemblyKey = GetAssemblyCacheKey(compiledResult.ResultAssembly);
+            Assembly a = (Assembly)HttpRuntime.Cache.Get(assemblyKey);
+            // TODO: Migration
+            // if (a == null) {
+            //     Debug.WriteLine("BuildResultCache", "Adding marker cache entry " + compiledResult.ResultAssembly);
+            //     // VSWhidbey 500049 - add as NotRemovable to prevent the assembly from being prematurely deleted
+            //     HttpRuntime.Cache.Insert(assemblyKey, compiledResult.ResultAssembly,
+            //         new CacheInsertOptions() { Priority = CacheItemPriority.NotRemovable });
+            // }
+            // else {
+            //     Debug.Assert(a == compiledResult.ResultAssembly);
+            // }
+
+            // Now create a dependency based on that key. This way, by removing that key, we are able to
+            // remove all the pages that live in that assembly from the cache.
+            CacheDependency assemblyCacheDependency = new CacheDependency(null, new string[] { assemblyKey });
+
+            // TODO: Migration
+            // if (cacheDependency != null) {
+            //     // We can't share the same CacheDependency, since we don't want the UtcStart
+            //     // behavior for the assembly.  Use an Aggregate to put the two together.
+            //     AggregateCacheDependency tmpDependency = new AggregateCacheDependency();
+            //     tmpDependency.Add(new CacheDependency[] { cacheDependency, assemblyCacheDependency });
+            //     cacheDependency = tmpDependency;
+            // }
+            // else {
+            cacheDependency = assemblyCacheDependency;
+            // }
+        }
+
+        string key = GetMemoryCacheKey(cacheKey);
+
+        // Only allow the cache item to expire if the result can be unloaded.  Otherwise,
+        // we may as well cache it forever (e.g. for Assemblies and Types).
+        CacheItemPriority cachePriority;
+        if (result.IsUnloadable)
+            cachePriority = CacheItemPriority.Default;
+        else
+            cachePriority = CacheItemPriority.NotRemovable;
+
+        CacheItemRemovedCallback onRemoveCallback = null;
+
+        // If the appdomain needs to be shut down when the item becomes invalid, register
+        // a callback to do the shutdown.
+        if (result.ShutdownAppDomainOnChange || result is BuildResultCompiledAssemblyBase)
+        {
+
+            // Create the delegate on demand
+            if (_onRemoveCallback == null)
+                _onRemoveCallback = new CacheItemRemovedCallback(OnCacheItemRemoved);
+
+            onRemoveCallback = _onRemoveCallback;
+        }
+
+        HttpRuntime.Cache.Insert(key, result, cacheDependency, result.MemoryCacheExpiration,
+            result.MemoryCacheSlidingExpiration, cachePriority, onRemoveCallback);
+    }
+
+    // OnCacheItemRemoved can be invoked with user code on the stack, for example if someone
+    // implements VirtualPathProvider.GetCacheDependency to return a custom CacheDependency.
+    // This callback needs PathDiscovery, Read, and Write permission.
+    private void OnCacheItemRemoved(string key, object value, CacheItemRemovedReason reason)
+    {
+
+        // Only handle case when the dependency is removed.
+        if (reason == CacheItemRemovedReason.DependencyChanged)
+        {
+            Debug.WriteLine("BuildResultCache", "OnCacheItemRemoved Key=" + key);
+
+            // Remove the assembly if a buildresult becomes obsolete
+            // TODO: Migration
+            // if (HostingEnvironment.ShutdownInitiated) {
+            //     // VSWhidbey 564168
+            //     // We still need to mark the affected files and dependencies for later deletion so that we do not build up unused assemblies.
+            //     RemoveAssemblyAndCleanupDependenciesShuttingDown(value as BuildResultCompiledAssembly);
+            // }
+            // else {
+
+            RemoveAssemblyAndCleanupDependencies(value as BuildResultCompiledAssemblyBase);
+
+            // Shutdown the appdomain if the buildresult requires it.
+            if (((BuildResult)value).ShutdownAppDomainOnChange)
+            {
+                // Dev10 823114
+                // At this point in code, it is possible that the current thread have acquired the CompilationMutex, and calling
+                // InitiateShutdownWithoutDemand will result in an acquisition of the lock on LockableAppDomainContext.
+                // A deadlock would happen if another thread were starting up, having acquired the lock on LockableAppDomainContext
+                // and going on to perform some compilation thus waiting on the CompilationMutex.
+                // In order to avoid the deadlock, we perform the call to InitiateShutdownWithoutDemand on a separate thread,
+                // so that it is possible for the current thread to continue without blocking or waiting on any lock, and
+                // to release the CompilationMutex later on.
+
+                ThreadPool.QueueUserWorkItem(new WaitCallback(MemoryBuildResultCache.ShutdownCallBack),
+                    "BuildResult change, cache key=" + key);
+            }
+            // }
+        }
+    }
+
+    static private void ShutdownCallBack(Object state)
+    {
+        string message = state as string;
+        // TODO: Migration
+        // if (message != null) {
+        //     HttpRuntime.SetShutdownReason(ApplicationShutdownReason.BuildManagerChange, message);
+        // }
+        // HostingEnvironment.InitiateShutdownWithoutDemand();
+    }
+
+    // Since we are shutting down, we will just create the .delete files to mark the files for deletion,
+    // and not try to get the compilation lock.
+    internal void RemoveAssemblyAndCleanupDependenciesShuttingDown(BuildResultCompiledAssemblyBase compiledResult)
+    {
+        if (compiledResult == null)
+            return;
+
+        if (compiledResult != null && compiledResult.ResultAssembly != null && !compiledResult.UsesExistingAssembly)
+        {
+            string assemblyName = compiledResult.ResultAssembly.GetName().Name;
+            lock (_dependentAssemblies)
+            {
+                RemoveAssemblyAndCleanupDependenciesNoLock(assemblyName);
+            }
+        }
+    }
+
+
+    internal void RemoveAssemblyAndCleanupDependencies(BuildResultCompiledAssemblyBase compiledResult)
+    {
+        if (compiledResult == null)
+            return;
+
+        if (compiledResult != null && compiledResult.ResultAssembly != null && !compiledResult.UsesExistingAssembly)
+        {
+            RemoveAssemblyAndCleanupDependencies(compiledResult.ResultAssembly.GetName().Name);
+        }
+    }
+
+    private void RemoveAssemblyAndCleanupDependencies(string assemblyName)
+    {
+        bool gotLock = false;
+
+        try
+        {
+            // Grab the compilation mutex, since we will remove cached build result
+            CompilationLock.GetLock(ref gotLock);
+
+            // Protect the dependent assemblies table, as it's accessed/modified in the recursion
+            lock (_dependentAssemblies)
+            {
+                RemoveAssemblyAndCleanupDependenciesNoLock(assemblyName);
+            }
+        }
+        finally
+        {
+            // Always release the mutex if we had taken it
+            if (gotLock)
+            {
+                CompilationLock.ReleaseLock();
+            }
+
+            DiskBuildResultCache.ShutDownAppDomainIfRequired();
+        }
+    }
+
+    private void RemoveAssemblyAndCleanupDependenciesNoLock(string assemblyName)
+    {
+
+        // If we have no cache entry for this assembly, there is nothing to do
+        string cacheKey = GetAssemblyCacheKeyFromName(assemblyName);
+        Assembly assembly = (Assembly)HttpRuntime.Cache.Get(cacheKey);
+        if (assembly == null)
+            return;
+
+        // Get the physical path to the assembly
+        String assemblyPath = Util.GetAssemblyCodeBase(assembly);
+
+        Debug.WriteLine("BuildResultCache",
+            "removing cacheKey for assembly " + assemblyPath + " because of dependency change");
+
+        // Remove the cache entry in order to kick out all the pages that are in that batch
+        HttpRuntime.Cache.Remove(cacheKey);
+
+        // Now call recursively on all the dependent assemblies (VSWhidbey 577593)
+        ICollection dependentAssemblies = _dependentAssemblies[assemblyName] as ICollection;
+        if (dependentAssemblies != null)
+        {
+            foreach (string dependentAssemblyName in dependentAssemblies)
+            {
+                RemoveAssemblyAndCleanupDependenciesNoLock(dependentAssemblyName);
+            }
+
+            // We can now remove this assembly from the hashtable
+            _dependentAssemblies.Remove(cacheKey);
+        }
+
+        // Remove (or rename) the DLL
+        RemoveAssembly(assemblyPath);
+    }
+
+    private static void RemoveAssembly(string path)
+    {
+        var f = new FileInfo(path);
+        DiskBuildResultCache.RemoveAssembly(f);
+        // Delete the associated pdb file as well, since it is possible to
+        // run into a situation where the dependency has changed just
+        // when the cache item is about to get inserted, resulting in
+        // the callback deleting only the dll file and leaving behind the
+        // pdb file. (Dev10 bug 846606)
+        var pdbPath = Path.ChangeExtension(f.FullName, ".pdb");
+        if (File.Exists(pdbPath))
+        {
+            DiskBuildResultCache.TryDeleteFile(new FileInfo(pdbPath));
+        }
+    }
+
+    private static string GetMemoryCacheKey(string cacheKey)
+    {
+
+        // Prepend something to it to avoid conflicts with other cache users
+        // todo: migration
+        return cacheKey;
+        // return CacheInternal.PrefixMemoryBuildResult + cacheKey;
+    }
+}
+
+internal abstract class DiskBuildResultCache : BuildResultCache
+{
+
+    protected const string preservationFileExtension = ".compiled";
+
+    protected string _cacheDir;
+
+    private static int s_recompilations;
+    private static int s_maxRecompilations = -1;
+
+    private static bool s_inUseAssemblyWasDeleted;
+
+    protected const string dotDelete = ".delete";
+
+    private static int s_shutdownStatus;
+    private const int SHUTDOWN_NEEDED = 1;
+    private const int SHUTDOWN_STARTED = 2;
+
+    internal DiskBuildResultCache(string cacheDir)
+    {
+        _cacheDir = cacheDir;
+
+        // Find out how many recompilations we allow before restarting the appdomain
+        // TODO: Migration
+        // if (s_maxRecompilations < 0)
+        //     s_maxRecompilations = CompilationUtil.GetRecompilationsBeforeAppRestarts();
+    }
+
+    protected void EnsureDiskCacheDirectoryCreated()
+    {
+
+        // Create the disk cache directory if it's not already there
+        if (!FileUtil.DirectoryExists(_cacheDir))
+        {
+            try
+            {
+                Directory.CreateDirectory(_cacheDir);
+            }
+            catch (IOException e)
+            {
+                // TODO: Migration
+                // throw new HttpException(SR.GetString(SR.Failed_to_create_temp_dir, HttpRuntime.GetSafePath(_cacheDir)), e);
+                throw new HttpException(SR.GetString(SR.Failed_to_create_temp_dir, _cacheDir), e);
+            }
+        }
+    }
+
+    internal override BuildResult GetBuildResult(string cacheKey, VirtualPath virtualPath, long hashCode,
+        bool ensureIsUpToDate)
+    {
+
+        Debug.WriteLine("BuildResultCache", "Looking for '" + cacheKey + "' in the disk cache");
+
+        string preservationFile = GetPreservedDataFileName(cacheKey);
+
+        PreservationFileReader pfr = new PreservationFileReader(this, PrecompilationMode);
+
+        // Create the BuildResult from the preservation file
+        BuildResult result = pfr.ReadBuildResultFromFile(virtualPath, preservationFile, hashCode, ensureIsUpToDate);
+
+        if (result != null)
+            Debug.WriteLine("BuildResultCache", "'" + cacheKey + "' was found in the disk cache");
+        else
+            Debug.WriteLine("BuildResultCache", "'" + cacheKey + "' was not found in the disk cache");
+
+        return result;
+    }
+
+    internal override void CacheBuildResult(string cacheKey, BuildResult result,
+        long hashCode, DateTime utcStart)
+    {
+
+        // If it should not be cached to disk, leave it alone
+        if (!result.CacheToDisk)
+            return;
+
+        // VSWhidbey 564168 don't save to disk if already shutting down, otherwise we might
+        // be persisting assembly that was compiled with obsolete references.
+        // Since we are shutting down and not creating any cache, delete the compiled result
+        // as it will not be used in future.
+        // TODO: Migration
+        // if (HostingEnvironment.ShutdownInitiated) {
+        //     BuildResultCompiledAssemblyBase compiledResult = result as BuildResultCompiledAssemblyBase;
+        //
+        //     // DevDiv2 880034: check if ResultAssembly is null before calling GetName().
+        //     // UsesExistingAssembly could be true in updatable compilation scenarios.
+        //     if (compiledResult != null && compiledResult.ResultAssembly != null && !compiledResult.UsesExistingAssembly)
+        //         MarkAssemblyAndRelatedFilesForDeletion(compiledResult.ResultAssembly.GetName().Name);
+        //     return;
+        // }
+
+        string preservationFile = GetPreservedDataFileName(cacheKey);
+        PreservationFileWriter pfw = new PreservationFileWriter(PrecompilationMode);
+
+        pfw.SaveBuildResultToFile(preservationFile, result, hashCode);
+    }
+
+    private void MarkAssemblyAndRelatedFilesForDeletion(string assemblyName)
+    {
+        DirectoryInfo directory = new DirectoryInfo(_cacheDir);
+        // Get rid of the prefix "App_web", since related files don't have it
+        string baseName = assemblyName.Substring(BuildManager.WebAssemblyNamePrefix.Length);
+        FileInfo[] files = directory.GetFiles("*" + baseName + ".*");
+        foreach (FileInfo f in files)
+            CreateDotDeleteFile(f);
+    }
+
+    /*
+     * Return the physical full path to the preservation data file
+     */
+    private string GetPreservedDataFileName(string cacheKey)
+    {
+
+        // Make sure the key doesn't contain any invalid file name chars (VSWhidbey 263142)
+        cacheKey = Util.MakeValidFileName(cacheKey);
+
+        cacheKey = Path.Combine(_cacheDir, cacheKey);
+
+        cacheKey = FileUtil.TruncatePathIfNeeded(cacheKey, 9 /*length of ".compiled"*/);
+
+        // Use a ".compiled" extension for the preservation file
+        return cacheKey + preservationFileExtension;
+    }
+
+    protected virtual bool PrecompilationMode
+    {
+        get { return false; }
+    }
+
+    internal static bool InUseAssemblyWasDeleted
+    {
+        get { return s_inUseAssemblyWasDeleted; }
+    }
+
+    internal static void ResetAssemblyDeleted()
+    {
+        s_inUseAssemblyWasDeleted = false;
+    }
+
+    /*
+     * Delete an assembly and all its related files.  The assembly is typically named
+     * something like ASPNET.jnw_y10n.dll, while related files are simply jnw_y10n.*.
+     */
+    internal virtual void RemoveAssemblyAndRelatedFiles(string assemblyName)
+    {
+
+        Debug.WriteLine("DiskBuildResultCache", "RemoveAssemblyAndRelatedFiles(" + assemblyName + ")");
+
+        // If the name doesn't start with the prefix, the cleanup code doesn't apply
+        if (!assemblyName.StartsWith(BuildManager.WebAssemblyNamePrefix, StringComparison.Ordinal))
+        {
+            return;
+        }
+
+        // Get rid of the prefix, since related files don't have it
+        string baseName = assemblyName.Substring(BuildManager.WebAssemblyNamePrefix.Length);
+
+        bool gotLock = false;
+        try
+        {
+            // Grab the compilation mutex, since we will remove generated assembly
+            CompilationLock.GetLock(ref gotLock);
+
+            DirectoryInfo directory = new DirectoryInfo(_cacheDir);
+
+            // Find all the files that contain the base name
+            FileInfo[] files = directory.GetFiles("*" + baseName + ".*");
+            foreach (FileInfo f in files)
+            {
+
+                if (f.Extension == ".dll")
+                {
+                    // Notify existing buildresults that result assembly will be removed.
+                    // This is required otherwise new components can be compiled
+                    // with obsolete build results whose assembly has been removed.
+                    string assemblyKey = GetAssemblyCacheKey(f.FullName);
+                    HttpRuntime.Cache.Remove(assemblyKey);
+
+                    // Remove the assembly
+                    RemoveAssembly(f);
+
+                    // Also, remove satellite assemblies that may be associated with it
+                    StandardDiskBuildResultCache.RemoveSatelliteAssemblies(assemblyName);
+                }
+                else if (f.Extension == dotDelete)
+                {
+                    CheckAndRemoveDotDeleteFile(f);
+                }
+                else
+                {
+                    // Remove the file, or if not possible, rename it, so it'll get
+                    // cleaned up next time by RemoveOldTempFiles()
+
+                    TryDeleteFile(f);
+                }
+            }
+        }
+        finally
+        {
+            // Always release the mutex if we had taken it
+            if (gotLock)
+            {
+                CompilationLock.ReleaseLock();
+            }
+
+            DiskBuildResultCache.ShutDownAppDomainIfRequired();
+        }
+    }
+
+    internal static void RemoveAssembly(FileInfo f)
+    {
+
+        // If we are shutting down, just create the .delete file and exit quickly.
+        // TODO: Migration
+        // if (HostingEnvironment.ShutdownInitiated) {
+        //     CreateDotDeleteFile(f);
+        //     return;
+        // }
+
+        // VSWhidbey 564168 / Visual Studio QFE 4710
+        // The assembly could still be referenced and needed for compilation in some cases.
+        // Thus, if we cannot delete it, we create an empty .delete file,
+        // so that both will be later removed by RemoveOldTempFiles.
+
+        // If the file is already marked for deletion, we simply return, so that
+        // we do not double count it in s_recompilations.
+        if (HasDotDeleteFile(f.FullName))
+            return;
+
+        if (TryDeleteFile(f))
+            return;
+
+        // It had to be renamed, so increment the recompilations count,
+        // and restart the appdomain if it reaches the limit
+
+        Debug.WriteLine("DiskBuildResultCache", "RemoveAssembly: " + f.Name + " was renamed");
+
+        if (++s_recompilations == s_maxRecompilations)
+        {
+            s_shutdownStatus = SHUTDOWN_NEEDED;
+        }
+
+        // Remember the fact that we just invalidated an assembly, which can cause
+        // other BuildResults to become invalid as a side effect (VSWhidbey 269297)
+        s_inUseAssemblyWasDeleted = true;
+    }
+
+    static internal void ShutDownAppDomainIfRequired()
+    {
+        // VSWhidbey 610631 Stress Failure: Worker process throws exceptions while unloading app domain and re-tries over and over
+        // It is possible for a deadlock to happen when locks on ApplicationManager and the CompilationMutex
+        // are acquired in different orders in multiple threads.
+        // Thus, since ShutdownAppDomain acquires a lock on ApplicationManager, we always release the CompilationMutex
+        // before calling ShutdownAppDomain, in case another thread has acquired the lock on ApplicationManager and
+        // is waiting on the CompilationMutex.
+
+
+        if (s_shutdownStatus == SHUTDOWN_NEEDED &&
+            (Interlocked.Exchange(ref s_shutdownStatus, SHUTDOWN_STARTED) == SHUTDOWN_NEEDED))
+        {
+            // Perform the actual shutdown on another thread, so that
+            // this thread can proceed and release any compilation mutex it is
+            // holding and not have to block if another thread has acquired a
+            // lock on ApplicationManager.
+            // (DevDiv 158814)
+            ThreadPool.QueueUserWorkItem(new WaitCallback(DiskBuildResultCache.ShutdownCallBack));
+        }
+    }
+
+    static private void ShutdownCallBack(Object state /*not used*/)
+    {
+        // TODO: Migration
+        // HttpRuntime.ShutdownAppDomain(ApplicationShutdownReason.MaxRecompilationsReached,
+        //     "Recompilation limit of " + s_maxRecompilations + " reached");
+    }
+
+
+
+    internal static bool TryDeleteFile(string s)
+    {
+        return TryDeleteFile(new FileInfo(s));
+    }
+
+    // Returns true if we are able to delete the file. Otherwise, creates a .delete file and returns false.
+    internal static bool TryDeleteFile(FileInfo f)
+    {
+        if (f.Extension == dotDelete)
+            return CheckAndRemoveDotDeleteFile(f);
+
+        try
+        {
+            f.Delete();
+            Debug.WriteLine("DiskBuildResultCache", "TryDeleteFile removed " + f.Name);
+            return true;
+        }
+        catch
+        {
+        }
+
+        CreateDotDeleteFile(f);
+        return false;
+    }
+
+    // Checks if the file is .delete. If it is, check if the associated base file is still around.
+    // If associated base file is around, try to delete it. If success, delete the .delete.
+    // Returns true only if both base file and .delete are removed.
+    internal static bool CheckAndRemoveDotDeleteFile(FileInfo f)
+    {
+        if (f.Extension != dotDelete)
+            return false;
+
+        string baseName = Path.GetDirectoryName(f.FullName) + Path.DirectorySeparatorChar +
+                          Path.GetFileNameWithoutExtension(f.FullName);
+        if (FileUtil.FileExists(baseName))
+        {
+            try
+            {
+                File.Delete(baseName);
+                Debug.WriteLine("DiskBuildResultCache", "CheckAndRemoveDotDeleteFile deleted " + baseName);
+            }
+            catch
+            {
+                return false;
+            }
+        }
+
+        try
+        {
+            f.Delete();
+            Debug.WriteLine("DiskBuildResultCache", "CheckAndRemoveDotDeleteFile deleted " + f.Name);
+        }
+        catch
+        {
+        }
+
+        return true;
+    }
+
+    internal static bool HasDotDeleteFile(string s)
+    {
+        return File.Exists(s + dotDelete);
+    }
+
+    private static void CreateDotDeleteFile(FileInfo f)
+    {
+        if (f.Extension == dotDelete)
+            return;
+        string newName = f.FullName + dotDelete;
+        if (!File.Exists(newName))
+        {
+            try
+            {
+                (new StreamWriter(newName)).Close();
+                Debug.WriteLine("DiskBuildResultCache", "CreateDotDeleteFile succeeded: " + newName);
+            }
+            catch
+            {
+                Debug.WriteLine("DiskBuildResultCache", "CreateDotDeleteFile failed: " + newName);
+            } // If we fail the .delete probably just got created by another process.
+        }
+    }
+
+}
+
+internal class StandardDiskBuildResultCache : DiskBuildResultCache
+{
+
+    private const string fusionCacheDirectoryName = "assembly";
+    private const string webHashDirectoryName = "hash";
+
+    private static ArrayList _satelliteDirectories;
+
+    internal StandardDiskBuildResultCache(string cacheDir)
+        : base(cacheDir)
+    {
+
+        Debug.Assert(cacheDir == HttpRuntime2.CodegenDirInternal);
+
+        EnsureDiskCacheDirectoryCreated();
+
+        FindSatelliteDirectories();
+    }
+
+    private string GetSpecialFilesCombinedHashFileName()
+    {
+        return BuildManager.WebHashFilePath;
+    }
+
+    internal Tuple<long, long> GetPreservedSpecialFilesCombinedHash()
+    {
+        string fileName = GetSpecialFilesCombinedHashFileName();
+        return GetPreservedSpecialFilesCombinedHash(fileName);
+    }
+
+    /*
+     * Return the combined hash that was preserved to file.  Return 0 if not valid.
+     */
+    internal static Tuple<long, long> GetPreservedSpecialFilesCombinedHash(string fileName)
+    {
+        if (!FileUtil.FileExists(fileName))
+        {
+            return Tuple.Create<long, long>(0, 0);
+        }
+
+        try
+        {
+            string[] hashTokens = Util.StringFromFile(fileName)
+                .Split(new[] { ';' }, StringSplitOptions.RemoveEmptyEntries);
+
+            long value1, value2;
+            if ((hashTokens.Length == 2) &&
+                Int64.TryParse(hashTokens[0], NumberStyles.AllowHexSpecifier, CultureInfo.InvariantCulture,
+                    out value1) &&
+                Int64.TryParse(hashTokens[1], NumberStyles.AllowHexSpecifier, CultureInfo.InvariantCulture,
+                    out value2))
+            {
+                return Tuple.Create(value1, value2);
+            }
+
+        }
+        catch
+        {
+            // If anything went wrong (file not found, or bad format), return 0
+        }
+
+        return Tuple.Create<long, long>(0, 0);
+    }
+
+    internal void SavePreservedSpecialFilesCombinedHash(Tuple<long, long> hash)
+    {
+        string fileName = GetSpecialFilesCombinedHashFileName();
+        SavePreservedSpecialFilesCombinedHash(fileName, hash);
+    }
+
+    /*
+     * Preserve the combined hash of the special files to a file.
+     */
+    internal static void SavePreservedSpecialFilesCombinedHash(string hashFilePath, Tuple<long, long> hash)
+    {
+
+        Debug.Assert(hash != null && hash.Item1 != 0 && hash.Item2 != 0,
+            "SavePreservedSpecialFilesCombinedHash: hash0 != 0, hash1 != 0");
+
+        String hashDirPath = Path.GetDirectoryName(hashFilePath);
+
+        // Create the hashweb directory if needed
+        if (!FileUtil.DirectoryExists(hashDirPath))
+        {
+            Directory.CreateDirectory(hashDirPath);
+        }
+
+        using (var writer = new StreamWriter(hashFilePath, false, Encoding.UTF8))
+        {
+            writer.WriteLine(hash.Item1.ToString("x", CultureInfo.InvariantCulture));
+            writer.WriteLine(';');
+            writer.WriteLine(hash.Item2.ToString("x", CultureInfo.InvariantCulture));
+        }
+    }
+
+    private void FindSatelliteDirectories()
+    {
+
+        Debug.Assert(_satelliteDirectories == null);
+
+        //
+        // Look for all the subdirectories of the codegen dir that look like
+        // satellite assemblies dirs, and keep track of them
+        //
+
+        string[] subDirs = Directory.GetDirectories(_cacheDir);
+
+        foreach (string subDir in subDirs)
+        {
+            string subDirName = Path.GetFileNameWithoutExtension(subDir);
+
+            // Skip the fusion cache, since it's definitely not a culture (VSWhidbey 327716)
+            if (subDirName == fusionCacheDirectoryName)
+                continue;
+
+            // Skip the "hash" folder
+            if (subDirName == webHashDirectoryName)
+                continue;
+
+            if (Util.IsCultureName(subDirName))
+            {
+                if (_satelliteDirectories == null)
+                    _satelliteDirectories = new ArrayList();
+
+                _satelliteDirectories.Add(Path.Combine(_cacheDir, subDir));
+            }
+        }
+    }
+
+    internal static void RemoveSatelliteAssemblies(string baseAssemblyName)
+    {
+
+        if (_satelliteDirectories == null)
+            return;
+
+        //
+        // If any satellite directory contains a satellite assembly that's
+        // for the passed in assembly name, delete it.
+        //
+
+        string satelliteAssemblyName = baseAssemblyName + ".resources";
+
+        foreach (string satelliteDir in _satelliteDirectories)
+        {
+            string fullAssemblyPath = Path.Combine(satelliteDir, satelliteAssemblyName);
+
+            // Delete the DLL and PDB
+            Util.DeleteFileIfExistsNoException(fullAssemblyPath + ".dll");
+            Util.DeleteFileIfExistsNoException(fullAssemblyPath + ".pdb");
+        }
+    }
+
+
+    private void RemoveCodegenResourceDir() {
+        string path = BuildManager.CodegenResourceDir;
+        Debug.WriteLine("BuildResultCache", "Deleting codegen temporary resource directory: " + path);
+        if (Directory.Exists(path)){
+            try {
+                Directory.Delete(path, recursive:true);
+            }
+            catch { }
+        }
+    }
+
+    /*
+     * Delete all temporary files from the codegen directory (e.g. source files, ...)
+
+     */
+    internal void RemoveOldTempFiles() {
+        Debug.WriteLine("BuildResultCache", "Deleting old temporary files from " + _cacheDir);
+
+        RemoveCodegenResourceDir();
+
+        string codegen = _cacheDir + "\\";
+
+        // Go through all the files in the codegen dir
+        foreach (FileData fileData in FileEnumerator.Create(codegen)) {
+
+            // Skip directories
+            if (fileData.IsDirectory) continue;
+
+            // If it has a known extension, skip it
+            string ext = Path.GetExtension(fileData.Name);
+            if (ext == ".dll" || ext == ".pdb" || ext == ".web" || ext == ".ccu" || ext == ".prof" || ext == preservationFileExtension) {
+                continue;
+            }
+
+            // .delete files need to be removed.
+            if (ext != dotDelete) {
+                // Don't delete the temp file if it's named after a dll that's still around
+                // since it could still be useful for debugging.
+                // Note that we can't use GetFileNameWithoutExtension here because
+                // some of the files are named 5hvoxl6v.0.cs, and it would return
+                // 5hvoxl6v.0 instead of just 5hvoxl6v
+                int periodIndex = fileData.Name.LastIndexOf('.');
+                if (periodIndex > 0) {
+                    string baseName = fileData.Name.Substring(0, periodIndex);
+
+                    int secondPeriodIndex = baseName.LastIndexOf('.');
+                    if (secondPeriodIndex > 0) {
+                        baseName = baseName.Substring(0, secondPeriodIndex);
+                    }
+
+                    // Generated source files uses assemblyname as prefix so we should keep them.
+                    if (FileUtil.FileExists(codegen + baseName + ".dll"))
+                        continue;
+
+                    // other generated files, such as .cmdline, .err and .out need to add the
+                    // WebAssemblyNamePrefix, since they do not use the assembly name as prefix.
+                    if (FileUtil.FileExists(codegen + BuildManager.WebAssemblyNamePrefix + baseName + ".dll"))
+                        continue;
+                }
+            }
+            else {
+                // Additional logic for VSWhidbey 564168 / Visual Studio QFE 4710.
+                // Delete both original .dll and .delete if possible
+                DiskBuildResultCache.CheckAndRemoveDotDeleteFile(new FileInfo(fileData.FullName));
+                continue;
+            }
+
+            Debug.WriteLine("BuildResultCache", "Deleting old temporary files: " + fileData.FullName);
+            try {
+                File.Delete(fileData.FullName);
+            } catch { }
+        }
+    }
+
+    // private void RemoveCodegenResourceDir() {
+    //     string path = BuildManager.CodegenResourceDir;
+    //     Debug.WriteLine("BuildResultCache", "Deleting codegen temporary resource directory: " + path);
+    //     if (Directory.Exists(path)){
+    //         try {
+    //             Directory.Delete(path, recursive:true);
+    //         }
+    //         catch { }
+    //     }
+    // }
+
+    /*
+     * Delete all the files in the codegen directory
+     */
+     [SuppressMessage("Microsoft.Usage","CA1806:DoNotIgnoreMethodResults", MessageId="System.Web.UnsafeNativeMethods.DeleteShadowCache(System.String,System.String)",
+         Justification="Reviewed - we are just trying to clean up the codegen folder as much as possible, so it is ok to ignore any errors.")]
+     internal void RemoveAllCodegenFiles() {
+         Debug.WriteLine("BuildResultCache", "Deleting all files from " + _cacheDir);
+
+         RemoveCodegenResourceDir();
+
+         // Remove everything in the codegen directory, as well as all the subdirectories
+         // used for culture assemblies
+
+         // Go through all the files in the codegen dir.  Delete everything, except
+         // for the fusion cache, which is in the "assembly" subdirectory
+         foreach (FileData fileData in FileEnumerator.Create(_cacheDir)) {
+
+             // If it's a directories
+             if (fileData.IsDirectory) {
+
+                 // Skip the fusion cache
+                 if (fileData.Name == fusionCacheDirectoryName)
+                     continue;
+
+                 // Skip the "hash" folder
+                 if (fileData.Name == webHashDirectoryName)
+                     continue;
+
+                 // Skip the source files generated for the designer (VSWhidbey 138194)
+                 if (StringUtil.StringStartsWith(fileData.Name, CodeDirectoryCompiler.sourcesDirectoryPrefix))
+                     continue;
+
+                 try {
+                     // If it is a directory, only remove the files inside and not the directory itself
+                     // VSWhidbey 596757
+                     DeleteFilesInDirectory(fileData.FullName);
+                 }
+                 catch { } // Ignore all exceptions
+
+                 continue;
+             }
+
+             // VSWhidbey 564168 Do not delete files that cannot be deleted, these files are still
+             // referenced by other appdomains that are in the process of shutting down.
+             // We also do not rename as renaming can cause an assembly not to be found if another
+             // appdomain tries to compile against it.
+             DiskBuildResultCache.TryDeleteFile(fileData.FullName);
+         }
+
+
+         // Clean up the fusion shadow copy cache
+
+         // Todo : Migration
+         // AppDomainSetup appDomainSetup = Thread.GetDomain().SetupInformation;
+         // UnsafeNativeMethods.DeleteShadowCache(appDomainSetup.CachePath,
+         //     appDomainSetup.ApplicationName);
+     }
+
+    // Deletes all files in the directory, but leaves the directory there
+    internal void DeleteFilesInDirectory(string path)
+    {
+        // Todo : Migration
+        // Check if the directory exists
+        if (!Directory.Exists(path))
+        {
+            return;
+        }
+
+        // Get all files in the directory and delete them
+        var files = Directory.GetFiles(path, "*.*", SearchOption.AllDirectories);
+        foreach (var file in files)
+        {
+            File.Delete(file);
+        }
+
+        // Get all directories and delete them
+        var directories = Directory.GetDirectories(path, "*", SearchOption.AllDirectories);
+        // Sort directories by their depth, ensuring we delete from the deepest child up to avoid access issues
+        var sortedDirectories = directories.OrderByDescending(dir => dir.Length);
+        foreach (var directory in sortedDirectories)
+        {
+            Directory.Delete(directory, false);
+        }
+    }
+}
+
+internal abstract class PrecompBaseDiskBuildResultCache: DiskBuildResultCache {
+
+    // In precompilation, the preservation files go in the bin directory
+    internal PrecompBaseDiskBuildResultCache(string cacheDir) : base(cacheDir) { }
+}
+
+// Used when precompiling a site
+internal class PrecompilerDiskBuildResultCache: PrecompBaseDiskBuildResultCache {
+
+    internal PrecompilerDiskBuildResultCache(string cacheDir) : base(cacheDir) {
+
+        EnsureDiskCacheDirectoryCreated();
+    }
+}
+
+// Used when precompiling a site using updatable precompilation
+internal class UpdatablePrecompilerDiskBuildResultCache: PrecompilerDiskBuildResultCache {
+
+    internal UpdatablePrecompilerDiskBuildResultCache(string cacheDir) : base(cacheDir) { }
+
+    internal override void CacheBuildResult(string cacheKey, BuildResult result,
+        long hashCode, DateTime utcStart) {
+
+        // Don't create preservation files in bin for pages in the updatable model,
+        // because we turn them into a v1 style code behind, which works as a result of
+        // having the aspx file point to the bin class via an inherits attribute.
+        if (result is BuildResultCompiledTemplateType)
+            return;
+
+        base.CacheBuildResult(cacheKey, result, hashCode, utcStart);
+    }
+
+}
+
+// Used when a site is already precompiled
+internal class PrecompiledSiteDiskBuildResultCache: PrecompBaseDiskBuildResultCache {
+
+    internal PrecompiledSiteDiskBuildResultCache(string cacheDir) : base(cacheDir) {}
+
+    protected override bool PrecompilationMode { get { return true; } }
+
+    internal override void CacheBuildResult(string cacheKey, BuildResult result,
+        long hashCode, DateTime utcStart) {
+
+        // Nothing to cache to disk if the app is already precompiled
+    }
+
+    internal override void RemoveAssemblyAndRelatedFiles(string baseName) {
+        // Never remove precompiled files (we couldn't anyways since they're
+        // in the app dir)
+    }
+}

--- a/src/WebForms/Compilation/ClientBuildManagerCallback.cs
+++ b/src/WebForms/Compilation/ClientBuildManagerCallback.cs
@@ -1,0 +1,42 @@
+//------------------------------------------------------------------------------
+// <copyright file="ClientBuildManagerCallback.cs" company="Microsoft">
+//     Copyright (c) Microsoft Corporation.  All rights reserved.
+// </copyright>
+//------------------------------------------------------------------------------
+
+/************************************************************************************************************/
+
+
+namespace System.Web.Compilation {
+
+using System;
+using System.Security.Permissions;
+using System.CodeDom;
+using System.CodeDom.Compiler;
+using System.Web.UI;
+
+
+//
+// This is a callback class implemented by ClientBuildManager callers. It is used
+// to receive status information about the build.
+//
+public class ClientBuildManagerCallback : MarshalByRefObject {
+
+    // This includes both errors and warnings
+    public virtual void ReportCompilerError(CompilerError error) {}
+
+    public virtual void ReportParseError(ParserError error) {}
+
+    public virtual void ReportProgress(string message) {}
+
+    // DevDiv 180798. The default lease is 5 minutes, so we return null to allow compilation
+    // calls to exceed 5 minutes. In doing so, we need to call RemotingService.Disconnect
+    // to release the object.
+    public override object InitializeLifetimeService() {
+        return null;
+    }
+}
+
+}
+
+

--- a/src/WebForms/Compilation/CodeDirectoryCompiler.cs
+++ b/src/WebForms/Compilation/CodeDirectoryCompiler.cs
@@ -1,0 +1,390 @@
+//------------------------------------------------------------------------------
+// <copyright file="CodeDirectoryCompiler.cs" company="Microsoft">
+//     Copyright (c) Microsoft Corporation.  All rights reserved.
+// </copyright>
+//------------------------------------------------------------------------------
+
+
+using System.Runtime.InteropServices;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using WebForms;
+
+namespace System.Web.Compilation {
+
+using System;
+using System.IO;
+using System.Collections;
+using System.CodeDom.Compiler;
+using System.Configuration;
+using System.Globalization;
+using System.Web.Configuration;
+using System.Reflection;
+using System.Web.Hosting;
+using System.Web.Util;
+using System.Web.UI;
+
+// The different types of directory that we treat as 'Code' (with minor differences)
+internal enum CodeDirectoryType {
+    MainCode,       // The main /code directory
+    SubCode,        // Code subdirectories registered to be compiled separately
+    AppResources,   // The /Resources directory
+    LocalResources, // A /LocalResources directory (at any level)
+    WebReferences   // The /WebReferences directory
+}
+
+internal class CodeDirectoryCompiler {
+
+    private VirtualPath _virtualDir;
+    private CodeDirectoryType _dirType;
+    private StringSet _excludedSubdirectories;
+
+    private BuildProvidersCompiler _bpc;
+    private BuildProviderSet _buildProviders = new BuildProviderSet();
+
+    private bool _onlyBuildLocalizedResources;
+
+    static internal BuildResultMainCodeAssembly _mainCodeBuildResult;
+
+    internal static bool IsResourceCodeDirectoryType(CodeDirectoryType dirType) {
+        return dirType == CodeDirectoryType.AppResources || dirType == CodeDirectoryType.LocalResources;
+    }
+
+    internal static void CallAppInitializeMethod() {
+        if (_mainCodeBuildResult != null)
+            _mainCodeBuildResult.CallAppInitializeMethod();
+    }
+
+    internal static Assembly GetCodeDirectoryAssembly(VirtualPath virtualDir,
+        CodeDirectoryType dirType, string assemblyName,
+        StringSet excludedSubdirectories, bool isDirectoryAllowed) {
+
+        string physicalDir = virtualDir.MapPath();
+
+        if (!isDirectoryAllowed) {
+
+            // The directory should never exist in a precompiled app
+            if (Directory.Exists(physicalDir)) {
+                throw new HttpException(SR.GetString(SR.Bar_dir_in_precompiled_app, virtualDir));
+            }
+        }
+
+        bool supportLocalization = IsResourceCodeDirectoryType(dirType);
+
+        // Determine the proper cache key based on the type of directory we're processing
+        string cacheKey = assemblyName;
+
+        // Try the cache first
+        BuildResult result = BuildManager.GetBuildResultFromCache(cacheKey);
+        Assembly resultAssembly = null;
+
+        // If it's cached, just return it
+        if (result != null) {
+
+            // It should always be a BuildResultCompiledAssembly, though if there is
+            // a VirtualPathProvider doing very bad things, it may not (VSWhidbey 341701)
+            Debug.Assert(result is BuildResultCompiledAssembly);
+            if (result is BuildResultCompiledAssembly) {
+
+                // If it's the main code assembly, keep track of it so we can later call
+                // the AppInitialize method
+                if (result is BuildResultMainCodeAssembly) {
+                    Debug.Assert(dirType == CodeDirectoryType.MainCode);
+                    Debug.Assert(_mainCodeBuildResult == null);
+                    _mainCodeBuildResult = (BuildResultMainCodeAssembly) result;
+                }
+
+                resultAssembly = ((BuildResultCompiledAssembly)result).ResultAssembly;
+
+                if (!supportLocalization)
+                    return resultAssembly;
+
+                // We found a preserved resource assembly.  However, we may not be done,
+                // as the culture specific files may have changed.
+
+                // But don't make any further checks if the directory is not allowed (precomp secenario).
+                // In that case, we should always return the assembly (VSWhidbey 533498)
+                if (!isDirectoryAllowed)
+                    return resultAssembly;
+
+                BuildResultResourceAssembly buildResultResAssembly = (BuildResultResourceAssembly)result;
+
+                string newResourcesDependenciesHash = HashCodeCombiner.GetDirectoryHash(virtualDir);
+
+                // If the resources hash (which includes satellites) is up to date, we're done
+                if (newResourcesDependenciesHash == buildResultResAssembly.ResourcesDependenciesHash)
+                    return resultAssembly;
+           }
+        }
+
+        // If app was precompiled, don't attempt compilation
+        if (!isDirectoryAllowed)
+            return null;
+
+        // Check whether the virtual dir is mapped to a different application,
+        // which we don't support (VSWhidbey 218603).  But don't do this for LocalResource (VSWhidbey 237935)
+        if (dirType != CodeDirectoryType.LocalResources && !StringUtil.StringStartsWithIgnoreCase(physicalDir, HttpRuntime.AppDomainAppPath)) {
+            throw new HttpException(SR.GetString(SR.Virtual_codedir, virtualDir.VirtualPathString));
+        }
+
+        // If the directory doesn't exist, we may be done
+        if (!Directory.Exists(physicalDir)) {
+
+            // We're definitely done if it's not the main code dir
+            if (dirType != CodeDirectoryType.MainCode)
+                return null;
+
+            // If it is the main code dir, we're only done is there is no profile to compile
+            // since the profice gets built as part of the main assembly.
+            // TODO: Migration
+            // if (!ProfileBuildProvider.HasCompilableProfile)
+            //     return null;
+        }
+
+
+        // Otherwise, compile it
+
+        BuildManager.ReportDirectoryCompilationProgress(virtualDir);
+
+        DateTime utcStart = DateTime.UtcNow;
+
+        CodeDirectoryCompiler cdc = new CodeDirectoryCompiler(virtualDir,
+            dirType, excludedSubdirectories);
+
+        string outputAssemblyName = null;
+
+        if (resultAssembly != null) {
+            // If resultAssembly is not null, we are in the case where we just need to build
+            // the localized resx file in a resources dir (local or global)
+            Debug.Assert(supportLocalization);
+            outputAssemblyName = resultAssembly.GetName().Name;
+            cdc._onlyBuildLocalizedResources = true;
+        }
+        else {
+            outputAssemblyName = BuildManager.GenerateRandomAssemblyName(assemblyName);
+        }
+
+        BuildProvidersCompiler bpc =
+            new BuildProvidersCompiler(virtualDir, supportLocalization, outputAssemblyName);
+
+        cdc._bpc = bpc;
+
+        // Find all the build provider we want to compile from the code directory
+        cdc.FindBuildProviders();
+
+        // Give them to the BuildProvidersCompiler
+        bpc.SetBuildProviders(cdc._buildProviders);
+
+        // Compile them into an assembly
+        CompilerResults results = bpc.PerformBuild();
+
+        // Did we just compile something?
+        if (results != null) {
+            Debug.Assert(result == null);
+            Debug.Assert(resultAssembly == null);
+
+            // If there is already a loaded module with the same path, try to wait for it to be unloaded.
+            // Otherwise, we would end up loading this old assembly instead of the new one (VSWhidbey 554697)
+            DateTime waitLimit = DateTime.UtcNow.AddMilliseconds(3000);
+            // TODO: Migration
+            for (;;)
+            {
+                // TODO: Check
+                // IntPtr hModule = UnsafeNativeMethods.GetModuleHandle(results.PathToAssembly);
+                IntPtr hModule = NativeLibrary.Load(results.PathToAssembly);
+                if (hModule == IntPtr.Zero)
+                {
+                    NativeLibrary.Free(hModule);
+                    break;
+                }
+                NativeLibrary.Free(hModule);
+
+                Debug.WriteLine("CodeDirectoryCompiler", results.PathToAssembly + " is already loaded. Waiting a bit");
+
+                System.Threading.Thread.Sleep(250);
+
+                // Stop trying if the timeout was reached
+                if (DateTime.UtcNow > waitLimit) {
+                    Debug.WriteLine("CodeDirectoryCompiler", "Timeout waiting for old assembly to unload: " + results.PathToAssembly);
+                    throw new HttpException(SR.GetString(SR.Assembly_already_loaded, results.PathToAssembly));
+                }
+            }
+
+            resultAssembly = results.CompiledAssembly;
+        }
+
+        // It is possible that there was nothing to compile (and we're not in the
+        // satellite resources case)
+        if (resultAssembly == null)
+            return null;
+
+        // For the main code directory, use a special BuildResult that takes care of
+        // calling AppInitialize if it finds one
+        if (dirType == CodeDirectoryType.MainCode) {
+            // Keep track of it so we can later call the AppInitialize method
+            _mainCodeBuildResult = new BuildResultMainCodeAssembly(resultAssembly);
+
+            result = _mainCodeBuildResult;
+        }
+        else if (supportLocalization) {
+            result = new BuildResultResourceAssembly(resultAssembly);
+        }
+        else {
+            result = new BuildResultCompiledAssembly(resultAssembly);
+        }
+
+        result.VirtualPath = virtualDir;
+
+        // If compilations are optimized, we need to include the right dependencies, since we can no longer
+        // rely on everything getting wiped out when something in App_Code changes.
+        // But don't do this for local resources, since they have their own special way of
+        // dealing with dependencies (in BuildResultResourceAssembly.ComputeSourceDependenciesHashCode).
+        // It's crucial *not* to do it as it triggers a tricky infinite recursion due to the fact
+        // that GetBuildResultFromCacheInternal calls EnsureFirstTimeDirectoryInitForDependencies if
+        // there is at least one dependency
+        if (BuildManager.OptimizeCompilations && dirType != CodeDirectoryType.LocalResources) {
+            result.AddVirtualPathDependencies(new SingleObjectCollection(virtualDir.AppRelativeVirtualPathString));
+        }
+
+        // Top level assembly should not be cached to memory.  But LocalResources are *not*
+        // top level files, and do benefit from memory caching
+        if (dirType != CodeDirectoryType.LocalResources)
+            result.CacheToMemory = false;
+
+        // Cache it for next time
+        BuildManager.CacheBuildResult(cacheKey, result, utcStart);
+
+        return resultAssembly;
+    }
+
+    internal const string sourcesDirectoryPrefix = "Sources_";
+
+    internal static void GetCodeDirectoryInformation(
+        VirtualPath virtualDir, CodeDirectoryType dirType, StringSet excludedSubdirectories, int index,
+        out Type codeDomProviderType, out CompilerParameters compilerParameters,
+        out string generatedFilesDir) {
+
+        // Compute the full path to the directory we'll use to generate all
+        // the code files
+        generatedFilesDir = HttpRuntime2.CodegenDirInternal + "\\" +
+            sourcesDirectoryPrefix + virtualDir.FileName;
+
+        bool supportLocalization = IsResourceCodeDirectoryType(dirType);
+
+        // the index is used to retrieve the correct referenced assemblies
+        BuildProvidersCompiler bpc = new BuildProvidersCompiler(virtualDir, supportLocalization,
+            generatedFilesDir, index);
+
+        CodeDirectoryCompiler cdc = new CodeDirectoryCompiler(virtualDir,
+            dirType, excludedSubdirectories);
+        cdc._bpc = bpc;
+
+        // Find all the build provider we want to compile from the code directory
+        cdc.FindBuildProviders();
+
+        // Give them to the BuildProvidersCompiler
+        bpc.SetBuildProviders(cdc._buildProviders);
+
+        // Generate all the sources into the directory generatedFilesDir
+        bpc.GenerateSources(out codeDomProviderType, out compilerParameters);
+    }
+
+    private CodeDirectoryCompiler(VirtualPath virtualDir, CodeDirectoryType dirType,
+        StringSet excludedSubdirectories) {
+
+        _virtualDir = virtualDir;
+        _dirType = dirType;
+        _excludedSubdirectories = excludedSubdirectories;
+    }
+
+    private void FindBuildProviders() {
+
+        // If we need to build the profile, add its build provider
+        // TODO: Migration
+        // if (_dirType == CodeDirectoryType.MainCode && ProfileBuildProvider.HasCompilableProfile) {
+        //     _buildProviders.Add(ProfileBuildProvider.Create());
+        //
+        // }        `
+
+        ProcessDirectoryRecursive(_virtualDir.GetDirectory(), true /*topLevel*/);
+    }
+
+    private void AddFolderLevelBuildProviders(VirtualDirectory vdir, FolderLevelBuildProviderAppliesTo appliesTo) {
+        BuildManager.AddFolderLevelBuildProviders(_buildProviders, vdir.VirtualPath,
+            appliesTo, _bpc.CompConfig, _bpc.ReferencedAssemblies);
+    }
+
+    private void ProcessDirectoryRecursive(VirtualDirectory vdir, bool topLevel) {
+
+        // If it's a WebReferences directory, handle it using a single WebReferencesBuildProvider
+        // instead of creating a different BuildProvider for each file.
+        if (_dirType == CodeDirectoryType.WebReferences) {
+            // Create a build provider for the current directory
+            BuildProvider buildProvider = new WebReferencesBuildProvider(vdir);
+            buildProvider.SetVirtualPath(vdir.VirtualPath);
+            _buildProviders.Add(buildProvider);
+
+            AddFolderLevelBuildProviders(vdir, FolderLevelBuildProviderAppliesTo.WebReferences);
+        }
+        else if (_dirType == CodeDirectoryType.AppResources) {
+            AddFolderLevelBuildProviders(vdir, FolderLevelBuildProviderAppliesTo.GlobalResources);
+        }
+        else if (_dirType == CodeDirectoryType.LocalResources) {
+            AddFolderLevelBuildProviders(vdir, FolderLevelBuildProviderAppliesTo.LocalResources);
+        }
+        else if (_dirType == CodeDirectoryType.MainCode || _dirType == CodeDirectoryType.SubCode) {
+            AddFolderLevelBuildProviders(vdir, FolderLevelBuildProviderAppliesTo.Code);
+        }
+
+        // Go through all the files in the directory
+        foreach (VirtualFileBase child in vdir.Children) {
+
+            if (child.IsDirectory) {
+
+                // If we are at the top level of this code directory, and the current
+                // subdirectory is in the exclude list, skip it
+                if (topLevel && _excludedSubdirectories != null &&
+                    _excludedSubdirectories.Contains(child.Name)) {
+                    continue;
+                }
+
+                // Exclude the special FrontPage directory (VSWhidbey 116727)
+                if (child.Name == "_vti_cnf")
+                    continue;
+
+                ProcessDirectoryRecursive(child as VirtualDirectory, false /*topLevel*/);
+                continue;
+            }
+
+            // Don't look at individual files for WebReferences directories
+            if (_dirType == CodeDirectoryType.WebReferences)
+                continue;
+
+            // Skip neutral files if _onlyBuildLocalizedResources is true
+            if (IsResourceCodeDirectoryType(_dirType)) {
+                if (_onlyBuildLocalizedResources && System.Web.UI.Util.GetCultureName(child.VirtualPath) == null) {
+                    continue;
+                }
+            }
+
+            BuildProvider buildProvider = BuildManager.CreateBuildProvider(child.VirtualPath,
+                (IsResourceCodeDirectoryType(_dirType)) ?
+                    BuildProviderAppliesTo.Resources : BuildProviderAppliesTo.Code,
+                _bpc.CompConfig,
+                _bpc.ReferencedAssemblies, false /*failIfUnknown*/);
+
+            // Non-supported file type
+            if (buildProvider == null)
+                continue;
+
+            // For Page resources, don't generate a strongly typed class
+            if (_dirType == CodeDirectoryType.LocalResources && buildProvider is BaseResourcesBuildProvider) {
+                ((BaseResourcesBuildProvider)buildProvider).DontGenerateStronglyTypedClass();
+            }
+
+            _buildProviders.Add(buildProvider);
+        }
+    }
+}
+
+}

--- a/src/WebForms/Compilation/CompilationLock.cs
+++ b/src/WebForms/Compilation/CompilationLock.cs
@@ -1,0 +1,199 @@
+//------------------------------------------------------------------------------
+// <copyright file="CompilationLock.cs" company="Microsoft">
+//     Copyright (c) Microsoft Corporation.  All rights reserved.
+// </copyright>
+//------------------------------------------------------------------------------
+
+//#define MUTEXINSTRUMENTATION
+
+using System.Web.Hosting;
+
+namespace System.Web.Compilation {
+
+using System;
+using System.Threading;
+using System.Globalization;
+using System.Security.Principal;
+using System.Web.Util;
+using System.Web.Configuration;
+using System.Runtime.InteropServices;
+using System.Runtime.Versioning;
+using System.Diagnostics;
+
+internal sealed class CompilationMutex : IDisposable {
+
+    private String  _name;
+    private String  _comment;
+#if MUTEXINSTRUMENTATION
+    // Used to keep track of the stack when the mutex is obtained
+    private string _stackTrace;
+#endif
+
+    // ROTORTODO: replace unmanaged aspnet_isapi mutex with managed implementation
+#if !FEATURE_PAL // No unmanaged aspnet_isapi mutex in Coriolis
+    private Mutex   _mutex;
+
+    // Lock Status is used to drain out all worker threads out of Mutex ownership on
+    // app domain shutdown: -1 locked for good, 0 unlocked, N locked by a worker thread(s)
+    private int     _lockStatus;
+    private bool    _draining = false;
+#endif // !FEATURE_PAL
+
+    internal CompilationMutex(String name, String comment) {
+
+#if !FEATURE_PAL // No unmanaged aspnet_isapi mutex in Coriolis
+
+        // TODO: Migration
+        // Attempt to get the mutex string from the registry (VSWhidbey 415795)
+        // string mutexRandomName = (string) Misc.GetAspNetRegValue("CompilationMutexName",
+        //     null /*valueName*/, null /*defaultValue*/);
+        string mutexRandomName = null;
+
+        if (mutexRandomName != null) {
+            // If we were able to use the registry value, use it.  Also, we need to prepend "Global\"
+            // to the mutex name, to make sure it can be shared between a terminal server session
+            // and IIS (VSWhidbey 307523).
+            _name += @"Global\" + name + "-" + mutexRandomName;
+        }
+        else {
+            // If we couldn't get the reg value, don't use it, and prepend "Local\" to the mutex
+            // name to make it local to the session (and hence prevent hijacking)
+            _name += @"Local\" + name;
+        }
+
+        _comment = comment;
+
+        Debug.WriteLine("Mutex", "Creating Mutex " + MutexDebugName);
+
+        _mutex = new Mutex(false, _name);
+
+        Debug.WriteLine("Mutex", "Successfully created Mutex " + MutexDebugName);
+#endif // !FEATURE_PAL
+    }
+
+    ~CompilationMutex() {
+        Close();
+    }
+
+    void IDisposable.Dispose() {
+        Close();
+        System.GC.SuppressFinalize(this);
+    }
+
+    internal /*public*/ void Close() {
+
+#if !FEATURE_PAL // No unmanaged aspnet_isapi mutex in Coriolis
+
+        if (_mutex != null) {
+            _mutex.Dispose();
+            _mutex = null;
+        }
+#endif // !FEATURE_PAL
+    }
+
+    [ResourceExposure(ResourceScope.None)]
+    internal /*public*/ void WaitOne() {
+
+#if !FEATURE_PAL // No unmanaged aspnet_isapi mutex in Coriolis
+
+        if (_mutex == null)
+            throw new InvalidOperationException(SR.GetString(SR.CompilationMutex_Null));
+
+        // check the lock status
+        for (;;) {
+            int lockStatus = _lockStatus;
+
+            if (lockStatus == -1 || _draining)
+                throw new InvalidOperationException(SR.GetString(SR.CompilationMutex_Drained));
+
+            if (Interlocked.CompareExchange(ref _lockStatus, lockStatus+1, lockStatus) == lockStatus)
+                break; // got the lock
+        }
+
+        Debug.WriteLine("Mutex", "Waiting for mutex " + MutexDebugName);
+
+        _mutex.WaitOne();
+
+#if MUTEXINSTRUMENTATION
+        // Remember the stack trace for debugging purpose
+        _stackTrace = (new StackTrace()).ToString();
+#endif
+
+        Debug.WriteLine("Mutex", "Got mutex " + MutexDebugName);
+#endif // !FEATURE_PAL
+    }
+
+    internal /*public*/ void ReleaseMutex() {
+
+#if !FEATURE_PAL // No unmanaged aspnet_isapi mutex in Coriolis
+        if (_mutex == null)
+            throw new InvalidOperationException(SR.GetString(SR.CompilationMutex_Null));
+
+        Debug.WriteLine("Mutex", "Releasing mutex " + MutexDebugName);
+
+#if MUTEXINSTRUMENTATION
+        // Clear out the stack trace
+        _stackTrace = null;
+#endif
+
+        _mutex.ReleaseMutex();
+#endif // !FEATURE_PAL
+    }
+
+
+    private String MutexDebugName {
+        get {
+#if DBG
+            return (_comment != null) ? _name + " (" + _comment + ")" : _name;
+#else
+            return _name;
+#endif
+        }
+    }
+}
+
+internal static class CompilationLock {
+
+    private static CompilationMutex _mutex;
+
+    static CompilationLock() {
+
+        // Create the mutex (or just get it if another process created it).
+        // Make the mutex unique per application
+        // TODO: Migration
+        // int hashCode = StringUtil.GetNonRandomizedHashCode("CompilationLock" + HttpRuntime.AppDomainAppId.ToLower(CultureInfo.InvariantCulture));
+        int hashCode = StringUtil.GetNonRandomizedHashCode("CompilationLock" + HostingEnvironment.ApplicationID.ToLower(CultureInfo.InvariantCulture));
+
+
+        _mutex = new CompilationMutex(
+                        "CL" + hashCode.ToString("x", CultureInfo.InvariantCulture),
+                        "CompilationLock for " + HttpRuntime.AppDomainAppVirtualPath);
+    }
+
+    internal static void GetLock(ref bool gotLock) {
+
+        // The idea of this try/finally is to make sure that the statements are always
+        // executed together (VSWhidbey 319154)
+        // This code should be using a constrained execution region.
+        try {
+        }
+        finally {
+            // Always take the BuildManager lock *before* taking the mutex, to avoid possible
+            // deadlock situations (VSWhidbey 530732)
+#pragma warning disable 0618
+            //@TODO: This overload of Monitor.Enter is obsolete.  Please change this to use Monitor.Enter(ref bool), and remove the pragmas   -- Microsoft
+            Monitor.Enter(BuildManager.TheBuildManager);
+#pragma warning restore 0618
+            _mutex.WaitOne();
+            gotLock = true;
+        }
+    }
+
+    internal static void ReleaseLock() {
+        _mutex.ReleaseMutex();
+        Monitor.Exit(BuildManager.TheBuildManager);
+    }
+
+}
+
+}

--- a/src/WebForms/Compilation/DelayLoadType.cs
+++ b/src/WebForms/Compilation/DelayLoadType.cs
@@ -1,0 +1,213 @@
+//------------------------------------------------------------------------------
+// <copyright file="DelayLoadType.cs" company="Microsoft">
+//     Copyright (c) Microsoft Corporation.  All rights reserved.
+// </copyright>
+//------------------------------------------------------------------------------
+
+using System;
+using System.Reflection;
+using System.Web.UI;
+
+namespace System.Web.Compilation {
+    internal class DelayLoadType : Type {
+        private Type _type;
+        private string _assemblyName;
+        private string _typeName;
+
+        public DelayLoadType(string assemblyName, string typeName) {
+            _assemblyName = assemblyName;
+            _typeName = typeName;
+        }
+
+        internal static bool Enabled {
+            get {
+                return BuildManagerHost.InClientBuildManager;
+            }
+        }
+
+        public Type Type {
+            get {
+                if (_type == null) {
+                    Assembly a = Assembly.Load(_assemblyName);
+                    _type = a.GetType(_typeName);
+                }
+
+                return _type;
+            }
+        }
+
+        public string AssemblyName {
+            get {
+                return _assemblyName;
+            }
+        }
+
+        public string TypeName {
+            get {
+                return _typeName;
+            }
+        }
+
+        public override Assembly Assembly {
+            get {
+                return Type.Assembly;
+            }
+        }
+
+        public override string AssemblyQualifiedName {
+            get {
+                return Type.AssemblyQualifiedName;
+            }
+        }
+
+        public override Type BaseType {
+            get {
+                return Type.BaseType;
+            }
+        }
+
+        public override string FullName {
+            get {
+                return Type.FullName;
+            }
+        }
+
+        public override Guid GUID {
+            get {
+                return Type.GUID;
+            }
+        }
+
+        protected override TypeAttributes GetAttributeFlagsImpl() {
+            return Type.Attributes;
+        }
+
+        protected override ConstructorInfo GetConstructorImpl(BindingFlags bindingAttr, Binder binder, CallingConventions callConvention, Type[] types, ParameterModifier[] modifiers) {
+            return Type.GetConstructor(bindingAttr, binder, callConvention, types, modifiers);
+        }
+
+        public override ConstructorInfo[] GetConstructors(BindingFlags bindingAttr) {
+            return Type.GetConstructors(bindingAttr);
+        }
+
+        public override Type GetElementType() {
+            return Type.GetElementType();
+        }
+
+        public override EventInfo GetEvent(string name, BindingFlags bindingAttr) {
+            return Type.GetEvent(name, bindingAttr);
+        }
+
+        public override EventInfo[] GetEvents(BindingFlags bindingAttr) {
+            return Type.GetEvents(bindingAttr);
+        }
+
+        public override FieldInfo GetField(string name, BindingFlags bindingAttr) {
+            return Type.GetField(name, bindingAttr);
+        }
+
+        public override FieldInfo[] GetFields(BindingFlags bindingAttr) {
+            return Type.GetFields(bindingAttr);
+        }
+
+        public override Type GetInterface(string name, bool ignoreCase) {
+            return Type.GetInterface(name, ignoreCase);
+        }
+
+        public override Type[] GetInterfaces() {
+            return Type.GetInterfaces();
+        }
+
+        public override MemberInfo[] GetMembers(BindingFlags bindingAttr) {
+            return Type.GetMembers(bindingAttr);
+        }
+
+        protected override MethodInfo GetMethodImpl(string name, BindingFlags bindingAttr, Binder binder, CallingConventions callConvention, Type[] types, ParameterModifier[] modifiers) {
+            return Type.GetMethod(name, bindingAttr, binder, callConvention, types, modifiers);
+        }
+
+        public override MethodInfo[] GetMethods(BindingFlags bindingAttr) {
+            return Type.GetMethods(bindingAttr);
+        }
+
+        public override Type GetNestedType(string name, BindingFlags bindingAttr) {
+            return Type.GetNestedType(name, bindingAttr);
+        }
+
+        public override Type[] GetNestedTypes(BindingFlags bindingAttr) {
+            return Type.GetNestedTypes(bindingAttr);
+        }
+
+        public override PropertyInfo[] GetProperties(BindingFlags bindingAttr) {
+            return Type.GetProperties(bindingAttr);
+        }
+
+        protected override PropertyInfo GetPropertyImpl(string name, BindingFlags bindingAttr, Binder binder, Type returnType, Type[] types, ParameterModifier[] modifiers) {
+            return Type.GetProperty(name, bindingAttr, binder, returnType, types, modifiers);
+        }
+
+        protected override bool HasElementTypeImpl() {
+            return Type.HasElementType;
+        }
+
+        public override object InvokeMember(string name, BindingFlags invokeAttr, Binder binder, object target, object[] args, ParameterModifier[] modifiers, System.Globalization.CultureInfo culture, string[] namedParameters) {
+            return Type.InvokeMember(name, invokeAttr, binder, target, args, modifiers, culture, namedParameters);
+        }
+
+        protected override bool IsArrayImpl() {
+            return Type.IsArray;
+        }
+
+        protected override bool IsByRefImpl() {
+            return Type.IsByRef;
+        }
+
+        protected override bool IsCOMObjectImpl() {
+            return Type.IsCOMObject;
+        }
+
+        protected override bool IsPointerImpl() {
+            return Type.IsPointer;
+        }
+
+        protected override bool IsPrimitiveImpl() {
+            return Type.IsPrimitive;
+        }
+
+        public override Module Module {
+            get {
+                return Type.Module;
+            }
+        }
+
+        public override string Namespace {
+            get {
+                return Type.Namespace;
+            }
+        }
+
+        public override Type UnderlyingSystemType {
+            get {
+                return Type.UnderlyingSystemType;
+            }
+        }
+
+        public override object[] GetCustomAttributes(Type attributeType, bool inherit) {
+            return Type.GetCustomAttributes(attributeType, inherit);
+        }
+
+        public override object[] GetCustomAttributes(bool inherit) {
+            return Type.GetCustomAttributes(inherit);
+        }
+
+        public override bool IsDefined(Type attributeType, bool inherit) {
+            return Type.IsDefined(attributeType, inherit);
+        }
+
+        public override string Name {
+            get {
+                return Type.Name;
+            }
+        }
+    }
+}

--- a/src/WebForms/Compilation/FolderLevelBuildProviderAppliesTo.cs
+++ b/src/WebForms/Compilation/FolderLevelBuildProviderAppliesTo.cs
@@ -1,0 +1,17 @@
+//------------------------------------------------------------------------------
+// <copyright file="FolderLevelBuildProviderAppliesTo.cs" company="Microsoft">
+//     Copyright (c) Microsoft Corporation.  All rights reserved.
+// </copyright>
+//------------------------------------------------------------------------------
+
+namespace System.Web.Compilation {
+
+    [Flags]
+    public enum FolderLevelBuildProviderAppliesTo {
+       None = 0,
+       Code = 1,
+       WebReferences = 2,
+       LocalResources = 4,
+       GlobalResources = 8,
+    }
+}


### PR DESCRIPTION
This commit introduces several new classes and interfaces for handling build providers and resources in the WebForms compilation process. It includes the addition of `BaseResourcesBuildProvider`, `BaseTemplateBuildProvider`, and other supporting classes to enhance resource generation and template parsing.

Key changes:
1. Added `BaseResourcesBuildProvider` for generating resources with support for strongly typed classes.
2. Introduced `BaseTemplateBuildProvider` for managing template parsing with enhanced dependency handling.
3. Implemented various utility classes (e.g., `BuildDependencySet`, `BuildProviderAppliesTo`) to manage build provider applications and dependencies more efficiently.
4. Integrated configuration sections such as `ProfileSection` and `PagesSection` using `System.Web.Configuration`.
5. Optimized the handling of assembly caching and memory management within `MemoryBuildResultCache` and `DiskBuildResultCache`.

These additions are aimed at improving the scalability and maintainability of the WebForms application compilation process, enabling better resource management and build customization capabilities.