### PR TITLE
Removing config and enabling SiteMap via option pattern

### DIFF
--- a/src/WebForms/SiteMapOptions.cs
+++ b/src/WebForms/SiteMapOptions.cs
@@ -1,0 +1,12 @@
+// MIT License.
+
+using System.Configuration;
+
+namespace System.Web;
+
+public class SiteMapOptions
+{
+    public string DefaultProvider { get; set; }
+    public bool? Enabled { get; set; }
+    public ICollection<ProviderSettings> Providers { get; } = [];
+}

--- a/test/Compiler.Dynamic.Tests/DynamicCompilationTests.cs
+++ b/test/Compiler.Dynamic.Tests/DynamicCompilationTests.cs
@@ -3,6 +3,7 @@
 using System.Diagnostics;
 using System.Net;
 using System.Text.Json.Serialization;
+using System.Web;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.DataProtection;
 using Microsoft.AspNetCore.Hosting;
@@ -123,6 +124,15 @@ public class DynamicCompilationTests
                         .AddScriptManager()
                         .AddDynamicPages();
                     services.AddSingleton<IDataProtectionProvider, NoopDataProtector>();
+                    if (test == "test14")
+                    {
+                        services.Configure<SiteMapOptions>(
+                            options =>
+                            {
+                                options.DefaultProvider = "AspNetXmlSiteMapProvider";
+                                options.Enabled = true;
+                            });
+                    }
                 });
             })
             .Start();


### PR DESCRIPTION
Fixing pending work #271 

Question for @twsouthwick , should we take this approach ? 
or should we populate automatically from Web.Config via WebResource ? One way I was thinking, get the configuration written to appsettings and configure from appsettings automatically, so that we can fix it for others https://learn.microsoft.com/en-us/dotnet/api/system.web.configuration?view=netframework-4.8.1 

Or let me know what other way you want to approach ?