### PR TITLE
Loading referenced assemblies to current app domain

### DIFF
--- a/Samples/WebFormsSample/ef.aspx
+++ b/Samples/WebFormsSample/ef.aspx
@@ -1,0 +1,22 @@
+<%@ Page Language="C#" AutoEventWireup="true" CodeBehind="ef.aspx.cs" Inherits="SystemWebUISample.Pages.ef" %>
+
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
+<script runat="server">
+    protected void Page_Load(object sender, EventArgs e) {
+       if (!Page.IsPostBack) {  
+           CallDB();
+       }
+    }
+</script>
+
+<html xmlns="http://www.w3.org/1999/xhtml" >
+<body>
+<form runat="server">
+ <asp:TextBox id="txt" runat="server" />
+    <p>
+        Entity Framework Test.
+    </p>
+</form>
+</body>
+
+</html>

--- a/Samples/WebFormsSample/ef.aspx.cs
+++ b/Samples/WebFormsSample/ef.aspx.cs
@@ -1,0 +1,46 @@
+// MIT License.
+
+using System.Web.UI;
+using System;
+using System.ComponentModel;
+using System.Collections.Generic;
+using WebFormsSample;
+using System.Data.Entity;
+
+namespace SystemWebUISample.Pages;
+
+public partial class ef : Page
+{
+    public void CallDB()
+    {
+        var author = new Author
+        {
+            FirstName = "William",
+            LastName = "Shakespeare"
+        };
+
+        using (var context = new SampleContext())
+        {
+            context.Authors.Add(author);
+        }
+        txt.Text = "EF Loaded.";
+    }
+
+    public class SampleContext : DbContext
+    {
+        public SampleContext()
+        {
+            Database.SetInitializer<SampleContext>(null);
+        }
+
+        public DbSet<Author>? Authors { get; set; }
+    }
+
+    public class Author
+    {
+        public int AuthorId { get; set; }
+        public string? FirstName { get; set; }
+        public string? LastName { get; set; }
+    }
+
+}

--- a/samples/WebFormsSample/WebFormsSample.Dynamic.csproj
+++ b/samples/WebFormsSample/WebFormsSample.Dynamic.csproj
@@ -15,4 +15,7 @@
     </Content>
   </ItemGroup>
 
+  <ItemGroup>
+    <PackageReference Include="EntityFramework" Version="6.5.1" />
+  </ItemGroup>
 </Project>

--- a/samples/WebFormsSample/WebFormsSample.Static.csproj
+++ b/samples/WebFormsSample/WebFormsSample.Static.csproj
@@ -12,5 +12,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNet.ScriptManager.MSAjax" Version="5.0.0" GeneratePathProperty="true" CopyContent="true" NoWarn="NU1701" />
   </ItemGroup>
-  
+  <ItemGroup>
+    <PackageReference Include="EntityFramework" Version="6.5.1" />
+  </ItemGroup>
 </Project>

--- a/samples/WebFormsSample/dynamic_page.aspx.cs
+++ b/samples/WebFormsSample/dynamic_page.aspx.cs
@@ -43,7 +43,7 @@ public partial class DynamicPage : Page
         Grid.DataSource = bindingList;
         Grid.DataBind();
     }
-    
+
     class Employee
     {
         public string FirstName { get; set; }

--- a/src/Compiler.Dynamic/DynamicControlCollection.cs
+++ b/src/Compiler.Dynamic/DynamicControlCollection.cs
@@ -14,51 +14,39 @@ internal sealed class DynamicControlCollection : ITypeResolutionService, IMetada
 {
     private readonly AssemblyLoadContext _context;
     private readonly ILogger<DynamicControlCollection> _logger;
-    private ImmutableHashSet<Assembly> _controls;
-    private ImmutableDictionary<AssemblyName, MetadataReference> _map;
+    private readonly Lazy<LoadedAssemblies> _loaded;
 
     public DynamicControlCollection(ILogger<DynamicControlCollection> logger)
     {
         _logger = logger;
-        _controls = ImmutableHashSet<Assembly>.Empty;
         _context = AssemblyLoadContext.Default;
-        _map = ImmutableDictionary<AssemblyName, MetadataReference>.Empty;
 
-        AppDomain.CurrentDomain.AssemblyLoad += CurrentDomain_AssemblyLoad;
+        _loaded = new(() =>
+        {
+            var loader = new LoadedAssemblies(_logger);
 
-        ProcessLoadedAssemblies();
+            AppDomain.CurrentDomain.AssemblyLoad += CurrentDomain_AssemblyLoad;
+
+            foreach (var assembly in _context.Assemblies)
+            {
+                loader.Load(assembly);
+            }
+
+            foreach (var file in Directory.EnumerateFiles(AppContext.BaseDirectory, "*.dll"))
+            {
+                loader.Load(file);
+            }
+
+            return loader;
+        });
     }
 
     private void CurrentDomain_AssemblyLoad(object? sender, AssemblyLoadEventArgs args)
-        => ProcessAssembly(args.LoadedAssembly);
+        => _loaded.Value.Load(args.LoadedAssembly);
 
-    private void ProcessLoadedAssemblies()
-    {
-        foreach (var assembly in _context.Assemblies)
-        {
-            ProcessAssembly(assembly);
-        }
-    }
+    IEnumerable<MetadataReference> IMetadataProvider.References => _loaded.Value.References;
 
-    private void ProcessAssembly(Assembly assembly)
-    {
-        _logger.LogTrace("Searching {Assembly} for tag prefixes", assembly.FullName);
-
-        if (assembly.GetCustomAttributes<TagPrefixAttribute>().Any())
-        {
-            _logger.LogInformation("Found tag prefixes in {Assembly}", assembly.FullName);
-            ImmutableInterlocked.Update(ref _controls, c => c.Add(assembly));
-        }
-
-        if (assembly is { Location: { Length: > 0 } location })
-        {
-            ImmutableInterlocked.TryAdd(ref _map, assembly.GetName(), MetadataReference.CreateFromFile(location));
-        }
-    }
-
-    IEnumerable<MetadataReference> IMetadataProvider.References => _map.Values;
-
-    IEnumerable<Assembly> IMetadataProvider.ControlAssemblies => _controls;
+    IEnumerable<Assembly> IMetadataProvider.ControlAssemblies => _loaded.Value.Controls;
 
     Assembly? ITypeResolutionService.GetAssembly(AssemblyName assemblyName)
     {
@@ -67,7 +55,7 @@ internal sealed class DynamicControlCollection : ITypeResolutionService, IMetada
 
     Type? ITypeResolutionService.GetType(string type)
     {
-        foreach (var control in _controls)
+        foreach (var control in _loaded.Value.Controls)
         {
             if (control.GetType(type, throwOnError: false) is { } found)
             {
@@ -107,5 +95,50 @@ internal sealed class DynamicControlCollection : ITypeResolutionService, IMetada
     void ITypeResolutionService.ReferenceAssembly(AssemblyName name)
     {
         throw new NotImplementedException();
+    }
+
+    private sealed class LoadedAssemblies(ILogger logger)
+    {
+        private ImmutableHashSet<Assembly> _controls = ImmutableHashSet<Assembly>.Empty;
+        private ImmutableDictionary<AssemblyName, MetadataReference> _map = ImmutableDictionary<AssemblyName, MetadataReference>.Empty;
+
+        public IEnumerable<Assembly> Controls => _controls;
+
+        public IEnumerable<MetadataReference> References => _map.Values;
+
+        public void Load(Assembly assembly)
+        {
+            logger.LogTrace("Searching {Assembly} for tag prefixes", assembly.FullName);
+
+            if (assembly.GetCustomAttributes<TagPrefixAttribute>().Any())
+            {
+                logger.LogInformation("Found tag prefixes in {Assembly}", assembly.FullName);
+                ImmutableInterlocked.Update(ref _controls, c => c.Add(assembly));
+            }
+
+            var assemblyName = assembly.GetName();
+
+            if (assembly is { Location: { Length: > 0 } location } && !_map.ContainsKey(assemblyName))
+            {
+                logger.LogTrace("Loading loaded {AssemblyName} for dynamic compilations", assemblyName);
+                ImmutableInterlocked.TryAdd(ref _map, assemblyName, MetadataReference.CreateFromFile(location));
+            }
+        }
+
+        public void Load(string file)
+        {
+            try
+            {
+                if (AssemblyName.GetAssemblyName(file) is { } assemblyName && !_map.ContainsKey(assemblyName))
+                {
+                    logger.LogTrace("Loading unloaded {AssemblyName} for dynamic compilations", assemblyName);
+                    ImmutableInterlocked.TryAdd(ref _map, assemblyName, MetadataReference.CreateFromFile(file));
+                }
+            }
+            catch (BadImageFormatException)
+            {
+                // Possibly a native assembly, so we'll ignore it
+            }
+        }
     }
 }


### PR DESCRIPTION
When EntityFramework being added to the sample project, the compilation for dynamic_page failed as it couldn't get EntityFramework related assemblies, although those are added as direct dependency. During Assembly load event, the EF dll is not getting loaded to the current appdomain, so forcing referenced assemblies load which are part of current application domain.