### PR TITLE
Add all *.dll in AppContext.BaseDirectory for dynamic compilation

### DIFF
--- a/Samples/WebFormsSample/ef.aspx
+++ b/Samples/WebFormsSample/ef.aspx
@@ -1,0 +1,28 @@
+<%@ Page Language="C#" %>
+
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
+
+<script runat="server">
+public class ProductContext : System.Data.Entity.DbContext
+{
+    public System.Data.Entity.DbSet<Category> Categories { get; set; }
+    public System.Data.Entity.DbSet<Product> Products { get; set; }
+}
+
+public class Category
+{
+}
+
+public class Product
+{
+}
+</script>
+
+<html xmlns="http://www.w3.org/1999/xhtml" >
+<body>
+    <h1>Entity Framework compilation</h1>
+    <p>
+        If this shows, then types from EF were able to be compiled.
+    </p>
+</body>
+</html>

--- a/samples/WebFormsSample/WebFormsSample.Dynamic.csproj
+++ b/samples/WebFormsSample/WebFormsSample.Dynamic.csproj
@@ -15,4 +15,8 @@
     </Content>
   </ItemGroup>
 
+  <ItemGroup>
+    <PackageReference Include="EntityFramework" Version="6.5.1" />
+  </ItemGroup>
+
 </Project>

--- a/src/Compiler.Dynamic/DynamicControlCollection.cs
+++ b/src/Compiler.Dynamic/DynamicControlCollection.cs
@@ -14,51 +14,39 @@ internal sealed class DynamicControlCollection : ITypeResolutionService, IMetada
 {
     private readonly AssemblyLoadContext _context;
     private readonly ILogger<DynamicControlCollection> _logger;
-    private ImmutableHashSet<Assembly> _controls;
-    private ImmutableDictionary<AssemblyName, MetadataReference> _map;
+    private readonly Lazy<LoadedAssemblies> _loaded;
 
     public DynamicControlCollection(ILogger<DynamicControlCollection> logger)
     {
         _logger = logger;
-        _controls = ImmutableHashSet<Assembly>.Empty;
         _context = AssemblyLoadContext.Default;
-        _map = ImmutableDictionary<AssemblyName, MetadataReference>.Empty;
 
-        AppDomain.CurrentDomain.AssemblyLoad += CurrentDomain_AssemblyLoad;
+        _loaded = new(() =>
+        {
+            var loader = new LoadedAssemblies(_logger);
 
-        ProcessLoadedAssemblies();
+            AppDomain.CurrentDomain.AssemblyLoad += CurrentDomain_AssemblyLoad;
+
+            foreach (var assembly in _context.Assemblies)
+            {
+                loader.Load(assembly);
+            }
+
+            foreach (var file in Directory.EnumerateFiles(AppContext.BaseDirectory, "*.dll"))
+            {
+                loader.Load(file);
+            }
+
+            return loader;
+        });
     }
 
     private void CurrentDomain_AssemblyLoad(object? sender, AssemblyLoadEventArgs args)
-        => ProcessAssembly(args.LoadedAssembly);
+        => _loaded.Value.Load(args.LoadedAssembly);
 
-    private void ProcessLoadedAssemblies()
-    {
-        foreach (var assembly in _context.Assemblies)
-        {
-            ProcessAssembly(assembly);
-        }
-    }
+    IEnumerable<MetadataReference> IMetadataProvider.References => _loaded.Value.References;
 
-    private void ProcessAssembly(Assembly assembly)
-    {
-        _logger.LogTrace("Searching {Assembly} for tag prefixes", assembly.FullName);
-
-        if (assembly.GetCustomAttributes<TagPrefixAttribute>().Any())
-        {
-            _logger.LogInformation("Found tag prefixes in {Assembly}", assembly.FullName);
-            ImmutableInterlocked.Update(ref _controls, c => c.Add(assembly));
-        }
-
-        if (assembly is { Location: { Length: > 0 } location })
-        {
-            ImmutableInterlocked.TryAdd(ref _map, assembly.GetName(), MetadataReference.CreateFromFile(location));
-        }
-    }
-
-    IEnumerable<MetadataReference> IMetadataProvider.References => _map.Values;
-
-    IEnumerable<Assembly> IMetadataProvider.ControlAssemblies => _controls;
+    IEnumerable<Assembly> IMetadataProvider.ControlAssemblies => _loaded.Value.Controls;
 
     Assembly? ITypeResolutionService.GetAssembly(AssemblyName assemblyName)
     {
@@ -67,7 +55,7 @@ internal sealed class DynamicControlCollection : ITypeResolutionService, IMetada
 
     Type? ITypeResolutionService.GetType(string type)
     {
-        foreach (var control in _controls)
+        foreach (var control in _loaded.Value.Controls)
         {
             if (control.GetType(type, throwOnError: false) is { } found)
             {
@@ -107,5 +95,50 @@ internal sealed class DynamicControlCollection : ITypeResolutionService, IMetada
     void ITypeResolutionService.ReferenceAssembly(AssemblyName name)
     {
         throw new NotImplementedException();
+    }
+
+    private sealed class LoadedAssemblies(ILogger logger)
+    {
+        private ImmutableHashSet<Assembly> _controls = ImmutableHashSet<Assembly>.Empty;
+        private ImmutableDictionary<AssemblyName, MetadataReference> _map = ImmutableDictionary<AssemblyName, MetadataReference>.Empty;
+
+        public IEnumerable<Assembly> Controls => _controls;
+
+        public IEnumerable<MetadataReference> References => _map.Values;
+
+        public void Load(Assembly assembly)
+        {
+            logger.LogTrace("Searching {Assembly} for tag prefixes", assembly.FullName);
+
+            if (assembly.GetCustomAttributes<TagPrefixAttribute>().Any())
+            {
+                logger.LogInformation("Found tag prefixes in {Assembly}", assembly.FullName);
+                ImmutableInterlocked.Update(ref _controls, c => c.Add(assembly));
+            }
+
+            var assemblyName = assembly.GetName();
+
+            if (assembly is { Location: { Length: > 0 } location } && !_map.ContainsKey(assemblyName))
+            {
+                logger.LogTrace("Loading loaded {AssemblyName} for dynamic compilations", assemblyName);
+                ImmutableInterlocked.TryAdd(ref _map, assemblyName, MetadataReference.CreateFromFile(location));
+            }
+        }
+
+        public void Load(string file)
+        {
+            try
+            {
+                if (AssemblyName.GetAssemblyName(file) is { } assemblyName && !_map.ContainsKey(assemblyName))
+                {
+                    logger.LogTrace("Loading unloaded {AssemblyName} for dynamic compilations", assemblyName);
+                    ImmutableInterlocked.TryAdd(ref _map, assemblyName, MetadataReference.CreateFromFile(file));
+                }
+            }
+            catch (BadImageFormatException)
+            {
+                // Possibly a native assembly, so we'll ignore it
+            }
+        }
     }
 }


### PR DESCRIPTION
As part of this, the loading of the assemblies are deferred out of the constructor itself to when it's actually needed