### PR TITLE
Use 5.11 of gitversion - it seems to work

### DIFF
--- a/.github/workflows/pack.yml
+++ b/.github/workflows/pack.yml
@@ -20,9 +20,7 @@ jobs:
     - name: Install GitVersion
       uses: gittools/actions/gitversion/setup@v3
       with:
-        # v5.10.0 of GitVersion has a fix for incorrect versions when building tags. See https://github.com/GitTools/GitVersion/issues/2838
-        # It appears that the fix then had a regression in a later version, so locking in 5.10.0.  See https://github.com/GitTools/GitVersion/issues/3351#issuecomment-1403657689
-        versionSpec: '5.10.0' 
+        versionSpec: '5.11.x' 
     - name: Determine Version
       uses: gittools/actions/gitversion/execute@v3
       with:

--- a/.github/workflows/pack.yml
+++ b/.github/workflows/pack.yml
@@ -20,7 +20,9 @@ jobs:
     - name: Install GitVersion
       uses: gittools/actions/gitversion/setup@v3
       with:
-        versionSpec: '6.0.x'
+        # v5.10.0 of GitVersion has a fix for incorrect versions when building tags. See https://github.com/GitTools/GitVersion/issues/2838
+        # It appears that the fix then had a regression in a later version, so locking in 5.10.0.  See https://github.com/GitTools/GitVersion/issues/3351#issuecomment-1403657689
+        versionSpec: '5.10.0' 
     - name: Determine Version
       uses: gittools/actions/gitversion/execute@v3
       with:


### PR DESCRIPTION
GitVersion 6.x doesn't seem to do the same SemVer calculations. For example, we expect it to have SemVer set to 0.4.0-ciXX, but with 6.x, it doesn't have that value. For now, reverting to 5.11 while we figure that out.
